### PR TITLE
Start MCP client before using it

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -47,7 +47,7 @@ func NewClient(mode, addressOrCommand string, args []string, env map[string]stri
 
 	// Create underlying MCP client based on mode
 	modeLower := strings.ToLower(mode)
-	var mcpClient client.MCPClient
+	var mcpClient *client.Client
 	var err error
 	switch modeLower {
 	case "stdio":
@@ -75,6 +75,10 @@ func NewClient(mode, addressOrCommand string, args []string, env map[string]stri
 	}
 	if err != nil {
 		return nil, customErrors.WrapMCPError(err, "client_creation", fmt.Sprintf("Failed to create MCP client for %s", addressOrCommand))
+	}
+
+	if err := mcpClient.Start(context.Background()); err != nil {
+		return nil, customErrors.WrapMCPError(err, "client_creation", fmt.Sprintf("Failed to start MCP client for %s", addressOrCommand))
 	}
 
 	// Create the wrapper client


### PR DESCRIPTION
When using using MCP over _SSE_ the client needs to be started first.

```
[INFO] slack-mcp-client: MCP Servers Configured (in file): 1
[INFO] slack-mcp-client: --- Starting MCP Client Initialization and Tool Discovery ---
[INFO] slack-mcp-client: Processing server: 'my-mcp-server'
[INFO] my-mcp-server: Creating MCP client mode=sse address=http://localhost:8087/mcp/sse
[INFO] mcp-client: Creating new MCP client mode=sse
[INFO] my-mcp-server: Successfully created MCP client instance
[INFO] my-mcp-server: Attempting to initialize MCP client (timeout: 5s)...
[INFO] mcp-client: Attempting to initialize MCP client server=http://localhost:8087/mcp/sse
[ERROR] mcp-client: MCP client initialization failed server=http://localhost:8087/mcp/sse error=transport error: transport not started yet
[INFO] mcp-client: Initialize request successful server=http://localhost:8087/mcp/sse
[INFO] my-mcp-server: MCP client successfully initialized
[INFO] my-mcp-server: Adding MCP client for 'my-mcp-server' to active client map
[INFO] my-mcp-server: Discovering tools (timeout: 20s)...
[INFO] mcp-client: Discovering tools server=http://localhost:8087/mcp/sse
[DEBUG] mcp-client: Client implements toolLister server=http://localhost:8087/mcp/sse
[WARN] mcp-client: First ListTools attempt failed server=http://localhost:8087/mcp/sse error=client not initialized
[WARN] mcp-client: Ping also failed server=http://localhost:8087/mcp/sse error=client not initialized
[ERROR] mcp-client: Tool discovery failed server=http://localhost:8087/mcp/sse error=client not initialized
[WARN] my-mcp-server: Failed to retrieve tools: [mcp:tool_discovery_failed] Failed to discover tools for http://localhost:8087/mcp/sse: client not initialized
[INFO] slack-mcp-client: --- Finished MCP Client Initialization and Tool Discovery ---
[INFO] slack-mcp-client: Successfully initialized 1 MCP clients: [my-mcp-server]
[INFO] slack-mcp-client: Failed to fully initialize/get tools from 1 servers: [my-mcp-server(tool discovery failed)]
[INFO] slack-mcp-client: Total unique discovered tools across all initialized servers: 0
[INFO] slack-mcp-client: Starting Slack client...
[INFO] slack-mcp-client: Setting Slack client log level from environment level=Debug
[INFO] slack-client: Available MCP servers (1):
[INFO] slack-client: - my-mcp-server
[INFO] slack-client: Available tools (0):
```