### PR TITLE
Add stdio frontend to test the client without involving slack

### DIFF
--- a/cmd/slack-mcp-client/main.go
+++ b/cmd/slack-mcp-client/main.go
@@ -438,7 +438,7 @@ func startSlackClient(logger *logging.Logger, mcpClients map[string]*mcp.Client,
 
 	var userFrontend slackbot.UserFrontend
 	if cfg.UseStdIOClient != nil && *cfg.UseStdIOClient {
-		userFrontend = slackbot.NewStidioClient(logger)
+		userFrontend = slackbot.NewStdioClient(logger)
 	} else {
 		userFrontend, err = slackbot.GetSlackClient(
 			cfg.SlackBotToken,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,11 +34,12 @@ type MCPServersConfig struct {
 
 // Config defines the overall application configuration
 type Config struct {
-	SlackBotToken string                            `json:"slack_bot_token"`
-	SlackAppToken string                            `json:"slack_app_token"`
-	Servers       map[string]ServerConfig           `json:"servers"`
-	LLMProvider   string                            `json:"llm_provider"`  // Name of the provider to USE (e.g., "openai", "ollama")
-	LLMProviders  map[string]map[string]interface{} `json:"llm_providers"` // Configuration for ALL potential providers
+	UseStdIOClient *bool                             `json:"use_stdio_client,omitempty"` // Use stdio client instead of Slack API
+	SlackBotToken  string                            `json:"slack_bot_token"`
+	SlackAppToken  string                            `json:"slack_app_token"`
+	Servers        map[string]ServerConfig           `json:"servers"`
+	LLMProvider    string                            `json:"llm_provider"`  // Name of the provider to USE (e.g., "openai", "ollama")
+	LLMProviders   map[string]map[string]interface{} `json:"llm_providers"` // Configuration for ALL potential providers
 }
 
 // LoadConfig loads configuration from file and environment variables

--- a/internal/slack/stdioClient.go
+++ b/internal/slack/stdioClient.go
@@ -1,0 +1,103 @@
+package slackbot
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+	"github.com/slack-go/slack/socketmode"
+	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
+	"io"
+	"os"
+)
+
+type StdioClient struct {
+	events chan socketmode.Event
+	Output io.Writer
+	Input  io.Reader
+	logger *logging.Logger
+}
+
+func NewStidioClient(stdLogger *logging.Logger) *StdioClient {
+	logLevel := getLogLevel(stdLogger)
+	stdioLogger := logging.New("stdio-client", logLevel)
+	return &StdioClient{
+		events: make(chan socketmode.Event, 50),
+		Output: os.Stdout,
+		Input:  os.Stdin,
+		logger: stdioLogger,
+	}
+}
+func (client StdioClient) GetConversationHistory(params *slack.GetConversationHistoryParameters) (*slack.GetConversationHistoryResponse, error) {
+	return nil, nil
+}
+func (client StdioClient) DeleteMessage(channel, messageTimestamp string) (string, string, error) {
+	return "", "", nil
+}
+func (client StdioClient) Run() error {
+	scanner := bufio.NewScanner(client.Input)
+	for scanner.Scan() {
+		e := socketmode.Event{
+			Type: socketmode.EventTypeEventsAPI,
+			Data: slackevents.EventsAPIEvent{
+				Token:        "",
+				TeamID:       "",
+				Type:         slackevents.CallbackEvent,
+				APIAppID:     "",
+				EnterpriseID: "",
+				Data:         nil,
+				InnerEvent: slackevents.EventsAPIInnerEvent{
+					Type: "",
+					Data: &slackevents.AppMentionEvent{
+						User:      "xxx",
+						Text:      scanner.Text(),
+						TimeStamp: "",
+						Channel:   "xxx",
+					},
+				},
+			},
+			Request: &socketmode.Request{},
+		}
+		client.events <- e
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error reading stdin: %w", err)
+	}
+	return nil
+}
+func (client StdioClient) Ack(req socketmode.Request, payload ...interface{}) {
+
+}
+func (client StdioClient) GetEventChannel() chan socketmode.Event {
+	return client.events
+}
+
+func (client StdioClient) RemoveBotMention(msg string) string {
+	return msg
+}
+
+func (client StdioClient) GetLogger() *logging.Logger {
+	return client.logger
+}
+
+func (client StdioClient) IsValidUser(userID string) bool {
+	return true
+}
+
+func (client StdioClient) IsBotUser(userID string) bool {
+	return false
+}
+
+func (client StdioClient) SendMessage(channelID, threadTS, text string) {
+	messages := []string{
+		"----- SEND MESSAGE -----\n",
+		text, "\n",
+		"----- END MESSAGE -----\n",
+	}
+	for _, msg := range messages {
+		_, err := client.Output.Write([]byte(msg))
+		if err != nil {
+			client.logger.ErrorKV("While writing message to output", "error", err)
+		}
+	}
+}

--- a/internal/slack/stdioClient.go
+++ b/internal/slack/stdioClient.go
@@ -18,7 +18,7 @@ type StdioClient struct {
 	logger *logging.Logger
 }
 
-func NewStidioClient(stdLogger *logging.Logger) *StdioClient {
+func NewStdioClient(stdLogger *logging.Logger) *StdioClient {
 	logLevel := getLogLevel(stdLogger)
 	stdioLogger := logging.New("stdio-client", logLevel)
 	return &StdioClient{

--- a/internal/slack/userFrontend.go
+++ b/internal/slack/userFrontend.go
@@ -1,0 +1,191 @@
+package slackbot
+
+import (
+	"context"
+	"fmt"
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/socketmode"
+	customErrors "github.com/tuannvm/slack-mcp-client/internal/common/errors"
+	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
+	"github.com/tuannvm/slack-mcp-client/internal/slack/formatter"
+	"os"
+	"regexp"
+	"strings"
+)
+
+type UserFrontend interface {
+	Run() error
+	Ack(req socketmode.Request, payload ...interface{})
+	GetEventChannel() chan socketmode.Event
+	RemoveBotMention(msg string) string
+	IsValidUser(userID string) bool
+	GetLogger() *logging.Logger
+	SendMessage(channelID, threadTS, text string)
+}
+
+func getLogLevel(stdLogger *logging.Logger) logging.LogLevel {
+	// Determine log level from environment variable
+	logLevel := logging.LevelInfo // Default to INFO
+	if envLevel := os.Getenv("LOG_LEVEL"); envLevel != "" {
+		logLevel = logging.ParseLevel(envLevel)
+		stdLogger.InfoKV("Setting Slack client log level from environment", "level", envLevel)
+	}
+	return logLevel
+}
+
+func GetSlackClient(botToken, appToken string, stdLogger *logging.Logger) (*SlackClient, error) {
+	if botToken == "" {
+		return nil, fmt.Errorf("SLACK_BOT_TOKEN must be set")
+	}
+	if appToken == "" {
+		return nil, fmt.Errorf("SLACK_APP_TOKEN must be set")
+	}
+	if !strings.HasPrefix(appToken, "xapp-") {
+		return nil, fmt.Errorf("SLACK_APP_TOKEN must have the prefix \"xapp-\"")
+	}
+
+	logLevel := getLogLevel(stdLogger)
+
+	// Create a structured logger for the Slack client
+	slackLogger := logging.New("slack-client", logLevel)
+
+	// Initialize the API client
+	api := slack.New(
+		botToken,
+		slack.OptionAppLevelToken(appToken),
+		// Still using standard logger for Slack API as it expects a standard logger
+		slack.OptionLog(slackLogger.StdLogger()),
+	)
+
+	// Authenticate with Slack
+	authTest, err := api.AuthTestContext(context.Background())
+	if err != nil {
+		return nil, customErrors.WrapSlackError(err, "authentication_failed", "Failed to authenticate with Slack")
+	}
+
+	mentionRegex := regexp.MustCompile(fmt.Sprintf("<@%s>", authTest.UserID))
+
+	// Create the socket mode client
+	client := socketmode.New(
+		api,
+		// Still using standard logger for socket mode as it expects a standard logger
+		socketmode.OptionLog(slackLogger.StdLogger()),
+		socketmode.OptionDebug(false),
+	)
+
+	return &SlackClient{
+		client,
+		mentionRegex,
+		authTest.UserID,
+		slackLogger,
+	}, nil
+}
+
+type SlackClient struct {
+	*socketmode.Client
+	botMentionRgx *regexp.Regexp
+	botUserID     string
+	logger        *logging.Logger
+}
+
+func (slackClient *SlackClient) GetEventChannel() chan socketmode.Event {
+	return slackClient.Events
+}
+
+func (slackClient *SlackClient) RemoveBotMention(msg string) string {
+	return slackClient.botMentionRgx.ReplaceAllString(msg, "")
+}
+
+func (slackClient *SlackClient) GetLogger() *logging.Logger {
+	return slackClient.logger
+}
+
+func (slackClient *SlackClient) IsValidUser(userID string) bool {
+	return userID != "" && !slackClient.IsBotUser(userID)
+}
+
+func (slackClient *SlackClient) IsBotUser(userID string) bool {
+	return userID == slackClient.botUserID
+}
+
+// SendMessage sends a message back to Slack, replying in a thread if threadTS is provided.
+func (slackClient *SlackClient) SendMessage(channelID, threadTS, text string) {
+	if text == "" {
+		slackClient.logger.WarnKV("Attempted to send empty message, skipping", "channel", channelID)
+		return
+	}
+
+	// Delete "typing" indicator messages if any
+	// This is a simplistic approach - more sophisticated approaches might track message IDs
+	history, err := slackClient.GetConversationHistory(&slack.GetConversationHistoryParameters{
+		ChannelID: channelID,
+		Limit:     10,
+	})
+	if err == nil && history != nil {
+		for _, msg := range history.Messages {
+			if slackClient.IsBotUser(msg.User) && msg.Text == "..." {
+				_, _, err := slackClient.DeleteMessage(channelID, msg.Timestamp)
+				if err != nil {
+					slackClient.logger.ErrorKV("Error deleting typing indicator message", "error", err)
+				}
+				break // Just delete the most recent one
+			}
+		}
+	}
+
+	// Detect message type and format accordingly
+	messageType := formatter.DetectMessageType(text)
+	slackClient.logger.DebugKV("Detected message type", "type", messageType, "length", len(text))
+
+	var msgOptions []slack.MsgOption
+
+	switch messageType {
+	case formatter.JSONBlock:
+		// Message is already in Block Kit JSON format
+		options := formatter.DefaultOptions()
+		options.Format = formatter.BlockFormat
+		options.ThreadTS = threadTS
+		msgOptions = formatter.FormatMessage(text, options)
+
+	case formatter.StructuredData:
+		// Convert structured data to Block Kit format
+		formattedText := formatter.FormatStructuredData(text)
+		options := formatter.DefaultOptions()
+		options.Format = formatter.BlockFormat
+		options.ThreadTS = threadTS
+		msgOptions = formatter.FormatMessage(formattedText, options)
+
+	case formatter.MarkdownText, formatter.PlainText:
+		// Apply Markdown formatting and use default text formatting
+		formattedText := formatter.FormatMarkdown(text)
+		options := formatter.DefaultOptions()
+		options.ThreadTS = threadTS
+		msgOptions = formatter.FormatMessage(formattedText, options)
+	}
+
+	// Send the message
+	_, _, err = slackClient.PostMessage(channelID, msgOptions...)
+	if err != nil {
+		slackClient.logger.ErrorKV("Error posting message to channel", "channel", channelID, "error", err, "messageType", messageType)
+
+		// If we get an error with Block Kit format, try falling back to plain text
+		if messageType == formatter.JSONBlock || messageType == formatter.StructuredData {
+			slackClient.logger.InfoKV("Falling back to plain text format due to Block Kit error", "channel", channelID)
+
+			// Apply markdown formatting to the original text and send as plain text
+			formattedText := formatter.FormatMarkdown(text)
+			fallbackOptions := []slack.MsgOption{
+				slack.MsgOptionText(formattedText, false),
+			}
+			if threadTS != "" {
+				fallbackOptions = append(fallbackOptions, slack.MsgOptionTS(threadTS))
+			}
+
+			// Try sending with plain text format
+			_, _, fallbackErr := slackClient.PostMessage(channelID, fallbackOptions...)
+			if fallbackErr != nil {
+				slackClient.logger.ErrorKV("Error posting fallback message to channel", "channel", channelID, "error", fallbackErr)
+			}
+		}
+	}
+}


### PR DESCRIPTION
- refactor client.go code to accept an interface for input/output
- create slack client wrapper
- create stdio client to accept and write messages
- add config flag to use stdio client as an option

This is useful for more quickly testing LLM/mcp server interactions, where slack isn't needed

Also a step towards having some parts of the code be more testable

Addresses #40 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for running the Slack client via standard input and output, enabling interaction without connecting to Slack.
  - Introduced a configuration option to select between Slack API and standard I/O modes.

- **Refactor**
  - Unified event handling and message sending through a new abstraction layer, streamlining how messages and events are processed.
  - Centralized user validation, bot mention handling, and logging for improved maintainability and flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->