### PR TITLE
Add thinkingMessage constant

### DIFF
--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -21,6 +21,8 @@ import (
 	"github.com/tuannvm/slack-mcp-client/internal/mcp"
 )
 
+const thinkingMessage = "Thinking..."
+
 // Client represents the Slack client application.
 type Client struct {
 	logger          *logging.Logger // Structured logger
@@ -249,7 +251,7 @@ func (c *Client) handleUserPrompt(userPrompt, channelID, threadTS string) {
 	c.addToHistory(channelID, "user", userPrompt) // Add user message to history
 
 	// Show a temporary "typing" indicator
-	c.userFrontend.SendMessage(channelID, threadTS, "Thinking...")
+	c.userFrontend.SendMessage(channelID, threadTS, thinkingMessage)
 
 	// Get context from history
 	contextHistory := c.getContextFromHistory(channelID)

--- a/internal/slack/userFrontend.go
+++ b/internal/slack/userFrontend.go
@@ -3,14 +3,16 @@ package slackbot
 import (
 	"context"
 	"fmt"
-	"github.com/slack-go/slack"
-	"github.com/slack-go/slack/socketmode"
-	customErrors "github.com/tuannvm/slack-mcp-client/internal/common/errors"
-	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
-	"github.com/tuannvm/slack-mcp-client/internal/slack/formatter"
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/socketmode"
+
+	customErrors "github.com/tuannvm/slack-mcp-client/internal/common/errors"
+	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
+	"github.com/tuannvm/slack-mcp-client/internal/slack/formatter"
 )
 
 type UserFrontend interface {
@@ -123,7 +125,7 @@ func (slackClient *SlackClient) SendMessage(channelID, threadTS, text string) {
 	})
 	if err == nil && history != nil {
 		for _, msg := range history.Messages {
-			if slackClient.IsBotUser(msg.User) && msg.Text == "..." {
+			if slackClient.IsBotUser(msg.User) && msg.Text == thinkingMessage {
 				_, _, err := slackClient.DeleteMessage(channelID, msg.Timestamp)
 				if err != nil {
 					slackClient.logger.ErrorKV("Error deleting typing indicator message", "error", err)


### PR DESCRIPTION
This PR fixes an issue where the `Thinking ...` message is not correctly deleted when posting the answer.

This is due to incorrect text message comparison. If fixed that by moving the thinking message into a constant and used it both when posting and finding/deleting the thinking message.