### PR TITLE
Add allow/block list for tools fetched from an mcp server

### DIFF
--- a/cmd/slack-mcp-client/main.go
+++ b/cmd/slack-mcp-client/main.go
@@ -243,8 +243,25 @@ func processSingleMCPServer(
 		return
 	}
 
+	blockListMap := map[string]bool{}
+	allowListMap := map[string]bool{}
+	for _, toolName := range serverConf.BlockList {
+		blockListMap[toolName] = true
+	}
+	for _, toolName := range serverConf.AllowList {
+		allowListMap[toolName] = true
+	}
+
 	serverLogger.Info("Discovered %d tools", len(listResult.Tools))
 	for _, toolDef := range listResult.Tools {
+		if _, exists := blockListMap[toolDef.Name]; exists {
+			serverLogger.Debug("    Tool '%s' is in block list, skipping", toolDef.Name)
+			continue
+		}
+		if len(allowListMap) > 0 && !allowListMap[toolDef.Name] {
+			serverLogger.Debug("    Tool '%s' is not in allow list, skipping", toolDef.Name)
+			continue
+		}
 		toolName := toolDef.Name
 		if _, exists := discoveredTools[toolName]; !exists {
 			var inputSchemaMap map[string]interface{}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,9 @@ type ServerConfig struct {
 	Env                      map[string]string `json:"env,omitempty"`                        // Environment variables
 	Disabled                 bool              `json:"disabled,omitempty"`                   // Whether this server is disabled
 	InitializeTimeoutSeconds *int              `json:"initialize_timeout_seconds,omitempty"` // Timeout for server initialization
+
+	AllowList []string `json:"allow_list,omitempty"` // List of allowed tools
+	BlockList []string `json:"block_list,omitempty"` // List of blocked tools
 }
 
 // MCPServersConfig is the top-level structure for the MCP servers configuration


### PR DESCRIPTION
- add allow/block list feature for tools retrieved from an mcp server

Fixes #44 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for allow and block lists to control which tools are processed by the server.
  - Tools can now be selectively enabled or disabled based on configuration settings.
  - Added logging to indicate when tools are skipped due to allow or block list rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->