### PR TITLE
feat: Add Anthropic/Claude LLM provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,10 +336,30 @@ LLM providers can be configured via environment variables or command-line flags:
 export LLM_PROVIDER="openai"
 export OPENAI_MODEL="gpt-4o"
 
+# Use Anthropic
+export LLM_PROVIDER="anthropic"
+export ANTHROPIC_API_KEY="your-anthropic-api-key"
+export ANTHROPIC_MODEL="claude-3-5-sonnet-20241022"
+
 # Or use Ollama
 export LLM_PROVIDER="ollama"
 export LANGCHAIN_OLLAMA_URL="http://localhost:11434"
 export LANGCHAIN_OLLAMA_MODEL="llama3"
+```
+
+### Switching Between Providers
+
+You can easily switch between providers by changing the `LLM_PROVIDER` environment variable:
+
+```bash
+# Use OpenAI
+export LLM_PROVIDER=openai
+
+# Use Anthropic
+export LLM_PROVIDER=anthropic
+
+# Use Ollama (local)
+export LLM_PROVIDER=ollama
 ```
 
 ## Configuration
@@ -352,8 +372,10 @@ The client can be configured using the following environment variables:
 | SLACK_APP_TOKEN       | App-level token for Socket Mode              | (required) |
 | OPENAI_API_KEY        | API key for OpenAI authentication            | (required) |
 | OPENAI_MODEL          | OpenAI model to use                          | gpt-4o     |
+| ANTHROPIC_API_KEY     | API key for Anthropic authentication         | (required for Anthropic) |
+| ANTHROPIC_MODEL       | Anthropic model to use                       | claude-3-5-sonnet-20241022 |
 | LOG_LEVEL             | Logging level (debug, info, warn, error)     | info       |
-| LLM_PROVIDER          | LLM provider to use (openai, ollama, etc.)   | openai     |
+| LLM_PROVIDER          | LLM provider to use (openai, anthropic, ollama) | openai     |
 | LANGCHAIN_OLLAMA_URL  | URL for Ollama when using LangChain          | http://localhost:11434 |
 | LANGCHAIN_OLLAMA_MODEL| Model name for Ollama when using LangChain   | llama3     |
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ import (
 const (
 	ProviderOpenAI    = "openai"
 	ProviderOllama    = "ollama"
+	ProviderAnthropic = "anthropic"
 	ProviderLangChain = "langchain" // Keep for potential direct LangChain use if needed
 )
 
@@ -58,9 +59,9 @@ func LoadConfig(configFile string, logger *logging.Logger) (*Config, error) {
 	cfg := &Config{
 		LLMProvider: ProviderOpenAI, // Default to OpenAI if not specified
 		LLMProviders: map[string]map[string]interface{}{
-			ProviderOpenAI: {"type": "openai", "model": "gpt-4o"},                                       // Default OpenAI model
-			ProviderOllama: {"type": "ollama", "model": "llama3", "base_url": "http://localhost:11434"}, // Default Ollama settings
-			// Add other providers with defaults here if needed
+			ProviderOpenAI:    {"type": "openai", "model": "gpt-4o"},                                       // Default OpenAI model
+			ProviderOllama:    {"type": "ollama", "model": "llama3", "base_url": "http://localhost:11434"}, // Default Ollama settings
+			ProviderAnthropic: {"type": "anthropic", "model": "claude-3-5-sonnet-20241022"},                // Default Anthropic model
 		},
 		Servers: make(map[string]ServerConfig),
 	}
@@ -137,6 +138,11 @@ func LoadConfig(configFile string, logger *logging.Logger) (*Config, error) {
 				"model":    "llama3",
 				"base_url": "http://localhost:11434",
 			}
+		case ProviderAnthropic:
+			cfg.LLMProviders[ProviderAnthropic] = map[string]interface{}{
+				"type":  "anthropic",
+				"model": "claude-3-5-sonnet-20241022",
+			}
 		default:
 			// For any other provider, create a basic config with langchain as the type
 			cfg.LLMProviders[cfg.LLMProvider] = map[string]interface{}{
@@ -155,6 +161,16 @@ func LoadConfig(configFile string, logger *logging.Logger) (*Config, error) {
 			providerConfig["model"] = model
 		}
 		cfg.LLMProviders[ProviderOpenAI] = providerConfig
+	}
+
+	if providerConfig, ok := cfg.LLMProviders[ProviderAnthropic]; ok {
+		if apiKey := os.Getenv("ANTHROPIC_API_KEY"); apiKey != "" {
+			providerConfig["api_key"] = apiKey
+		}
+		if model := os.Getenv("ANTHROPIC_MODEL"); model != "" {
+			providerConfig["model"] = model
+		}
+		cfg.LLMProviders[ProviderAnthropic] = providerConfig
 	}
 
 	return cfg, nil

--- a/internal/llm/anthropic_factory.go
+++ b/internal/llm/anthropic_factory.go
@@ -1,0 +1,58 @@
+package llm
+
+import (
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/anthropic"
+	customErrors "github.com/tuannvm/slack-mcp-client/internal/common/errors"
+	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
+)
+
+// AnthropicModelFactory creates Anthropic LangChain model instances
+type AnthropicModelFactory struct{}
+
+// Validate checks if the configuration is valid for Anthropic
+func (f *AnthropicModelFactory) Validate(config map[string]interface{}) error {
+	// API key is required for Anthropic
+	apiKey, ok := config["api_key"].(string)
+	if !ok || apiKey == "" {
+		return customErrors.NewLLMError("missing_config", "Anthropic config requires 'api_key' (string)")
+	}
+	return nil
+}
+
+// Create returns a new Anthropic LangChain model instance
+func (f *AnthropicModelFactory) Create(config map[string]interface{}, logger *logging.Logger) (llms.Model, error) {
+	modelName, _ := config["model"].(string)  // Already validated in parent factory
+	apiKey, _ := config["api_key"].(string)   // Already validated in Validate method
+	baseURL, _ := config["base_url"].(string) // Optional custom base URL
+
+	opts := []anthropic.Option{
+		anthropic.WithModel(modelName), // Set model during initialization
+		anthropic.WithToken(apiKey),    // API key is required
+	}
+
+	if baseURL != "" {
+		opts = append(opts, anthropic.WithBaseURL(baseURL))
+		logger.InfoKV("Configuring LangChain with Anthropic", "base_url", baseURL, "model", modelName)
+	} else {
+		logger.InfoKV("Configuring LangChain with Anthropic (default endpoint)", "model", modelName)
+	}
+
+	llmClient, err := anthropic.New(opts...)
+	if err != nil {
+		logger.ErrorKV("Failed to initialize LangChainGo Anthropic client", "error", err)
+
+		// Create a domain-specific error with additional context
+		domainErr := customErrors.WrapLLMError(err, "initialization_failed", "Failed to initialize Anthropic client")
+
+		// Add additional context data
+		domainErr = domainErr.WithData("model", modelName)
+		if baseURL != "" {
+			domainErr = domainErr.WithData("base_url", baseURL)
+		}
+
+		return nil, domainErr
+	}
+
+	return llmClient, nil
+}

--- a/internal/llm/langchain.go
+++ b/internal/llm/langchain.go
@@ -47,6 +47,7 @@ func init() {
 	// Register built-in model factories
 	RegisterLangChainModelFactory(ProviderTypeOpenAI, &OpenAIModelFactory{})
 	RegisterLangChainModelFactory(ProviderTypeOllama, &OllamaModelFactory{})
+	RegisterLangChainModelFactory(ProviderTypeAnthropic, &AnthropicModelFactory{})
 }
 
 // RegisterLangChainModelFactory registers a new model factory for the given provider type

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -14,6 +14,7 @@ import (
 const (
 	ProviderTypeOpenAI        = "openai"
 	ProviderTypeOllama        = "ollama"
+	ProviderTypeAnthropic     = "anthropic"
 	ProviderNameLangChain     = "langchain"
 	DefaultLLMGatewayProvider = ProviderNameLangChain
 )


### PR DESCRIPTION
# Add Anthropic/Claude LLM Provider Support

## Overview
This PR adds comprehensive support for Anthropic's Claude models to the Slack MCP Client, enabling users to switch between OpenAI, Anthropic, and Ollama providers seamlessly.

## Changes Made

### New Files
- `internal/llm/anthropic_factory.go` - Anthropic model factory implementation

### Modified Files
- `internal/llm/langchain.go` - Registered Anthropic factory
- `internal/llm/provider.go` - Added Anthropic provider constant
- `internal/config/config.go` - Added Anthropic configuration support
- `README.md` - Added provider switching documentation and configuration table

## Features Added
- **Anthropic Integration**: Full support for Claude models via LangChain Go
- **Environment Variables**: `ANTHROPIC_API_KEY`, `ANTHROPIC_MODEL`, `LLM_PROVIDER=anthropic`
- **Default Model**: Claude 3.5 Sonnet (`claude-3-5-sonnet-20241022`)
- **Provider Switching**: Easy switching between OpenAI, Anthropic, and Ollama
- **Documentation**: Updated README with usage examples

## Testing
✅ Successfully tested with Claude 3.5 Sonnet:
- API connection and authentication
- Chat completions and responses
- MCP tool integration (filesystem tools)
- Provider switching functionality

## Usage
```bash
# Switch to Anthropic
export LLM_PROVIDER=anthropic
export ANTHROPIC_API_KEY=your-api-key

# Run the application
./bin/slack-mcp-client --config mcp-servers.json
```

## Impact
- Expands LLM provider options for users
- Maintains backward compatibility
- Follows existing architecture patterns
- Production-ready implementation

The Slack MCP Client now supports three major LLM providers: OpenAI, Anthropic, and Ollama.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for Anthropic as a new LLM provider, allowing users to select and configure Anthropic models alongside existing providers.
- **Documentation**
	- Updated documentation to include configuration instructions and environment variables for Anthropic, as well as guidance on switching between providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->