### PR TITLE
Fix and improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine as builder
+FROM golang:1.24-alpine AS builder
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN go mod download
 COPY . .
 
 # Build the application
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o slack-mcp-client ./cmd/
+RUN --mount=type=cache,target=/go/pkg/mod CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o slack-mcp-client ./cmd/
 
 # Use a minimal alpine image
 FROM alpine:3.22


### PR DESCRIPTION
This PR bring 2 changes to the `Dockerfile`

- Add cache layer for the `go build` step to improve local development speed
- Fix the `as` directive which fails to build due to casing issue
```
$ make docker-build
docker build -t slack-mcp-client:latest .
 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
```

<details><summary>docker version 28.1.1</summary>

```
$ docker version
Client:
 Version:           28.1.1
 API version:       1.49
 Go version:        go1.24.2
 Git commit:        4eba377327
 Built:             Mon Apr 21 13:12:23 2025
 OS/Arch:           linux/amd64
 Context:           default

Server:
 Engine:
  Version:          28.1.1
  API version:      1.49 (minimum version 1.24)
  Go version:       go1.24.2
  Git commit:       01f442b84d
  Built:            Mon Apr 21 13:12:23 2025
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          v2.1.0
  GitCommit:        061792f0ecf3684fb30a3a0eb006799b8c6638a7.m
 runc:
  Version:          1.3.0
  GitCommit:
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved Docker build performance by enabling caching of Go module dependencies.
  - Updated Dockerfile syntax for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->