### PR TITLE
feat: replace current SSE MCP client with retrying wrapper

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -77,11 +77,11 @@ func NewClient(mode, addressOrCommand string, args []string, env map[string]stri
 			return nil, customErrors.WrapMCPError(err, "client_creation", fmt.Sprintf("Failed to create MCP client for %s", addressOrCommand))
 		}
 	case "sse":
-		mcpClient, err = client.NewSSEMCPClient(addressOrCommand)
+		mcpClient, err = NewSSEMCPClientWithRetry(addressOrCommand, mcpLogger)
 		if err != nil {
 			return nil, customErrors.WrapMCPError(err, "client_creation", fmt.Sprintf("Failed to create MCP client for %s", addressOrCommand))
 		}
-		err = mcpClient.(*client.Client).Start(context.Background())
+		err = mcpClient.(*SSEMCPClientWithRetry).Start(context.Background())
 		if err != nil {
 			return nil, customErrors.WrapMCPError(err, "client_start", fmt.Sprintf("Failed to start MCP client for %s", addressOrCommand))
 		}

--- a/internal/mcp/sseClient.go
+++ b/internal/mcp/sseClient.go
@@ -1,0 +1,196 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
+)
+
+const (
+	maxReconnectAttempts = 5
+	baseBackoffDuration  = time.Second
+)
+
+type SSEMCPClientWithRetry struct {
+	*client.Client
+
+	serverAddr string
+	log        *logging.Logger
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	mutex         sync.RWMutex
+	reconnectCh   chan struct{}
+	reconnectDone chan struct{}
+}
+
+func NewSSEMCPClientWithRetry(serverAddr string, log *logging.Logger) (*SSEMCPClientWithRetry, error) {
+	sseClient, err := client.NewSSEMCPClient(serverAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	c := &SSEMCPClientWithRetry{
+		Client:        sseClient,
+		serverAddr:    serverAddr,
+		log:           log,
+		ctx:           ctx,
+		cancel:        cancel,
+		reconnectCh:   make(chan struct{}, 1),
+		reconnectDone: nil,
+	}
+
+	go c.reconnectLoop()
+	return c, nil
+}
+
+func (c *SSEMCPClientWithRetry) Start(ctx context.Context) error {
+	return c.Client.Start(ctx)
+}
+
+func (c *SSEMCPClientWithRetry) CallTool(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	result, err := c.callTool(ctx, request)
+	if err == nil {
+		return result, nil
+	}
+
+	if !strings.Contains(err.Error(), "transport error") {
+		return nil, err
+	}
+
+	c.log.ErrorKV("Tool call failed, attempting reconnect", "error", err)
+
+	select {
+	case <-c.triggerReconnect():
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	result, err = c.callTool(ctx, request)
+	if err != nil {
+		return nil, fmt.Errorf("tool call failed after reconnect: %w", err)
+	}
+
+	return result, nil
+}
+
+func (c *SSEMCPClientWithRetry) callTool(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	if c.Client == nil {
+		return nil, fmt.Errorf("client not connected")
+	}
+	return c.Client.CallTool(ctx, request)
+}
+
+func (c *SSEMCPClientWithRetry) connect() error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if c.Client != nil {
+		if err := c.Client.Close(); err != nil {
+			return err
+		}
+	}
+
+	sseClient, err := client.NewSSEMCPClient(c.serverAddr)
+	if err != nil {
+		return err
+	}
+
+	if err = sseClient.Start(c.ctx); err != nil {
+		return err
+	}
+
+	initReq := mcp.InitializeRequest{}
+	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	if _, err = sseClient.Initialize(c.ctx, initReq); err != nil {
+		return err
+	}
+
+	c.Client = sseClient
+	return nil
+}
+
+// triggerReconnect schedules a reconnect if not already in progress and returns a channel that will be closed when it's done.
+func (c *SSEMCPClientWithRetry) triggerReconnect() <-chan struct{} {
+	select {
+	case c.reconnectCh <- struct{}{}:
+		c.mutex.Lock()
+		done := make(chan struct{})
+		c.reconnectDone = done
+		c.mutex.Unlock()
+		return done
+	default:
+		c.mutex.RLock()
+		done := c.reconnectDone
+		c.mutex.RUnlock()
+		if done == nil {
+			// edge case
+			noop := make(chan struct{})
+			close(noop)
+			return noop
+		}
+		return done
+	}
+}
+
+func (c *SSEMCPClientWithRetry) reconnectLoop() {
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-c.reconnectCh:
+			var success bool
+
+			for attempt := 1; attempt <= maxReconnectAttempts; attempt++ {
+				if err := c.connect(); err != nil {
+					c.log.InfoKV("Reconnect failed", "attempt", attempt, "error", err)
+
+					select {
+					case <-time.After(time.Duration(attempt) * baseBackoffDuration):
+					case <-c.ctx.Done():
+						return
+					}
+				} else {
+					c.log.Info("Reconnected successfully")
+					success = true
+					break
+				}
+			}
+
+			c.mutex.Lock()
+			if c.reconnectDone != nil {
+				close(c.reconnectDone)
+				c.reconnectDone = nil
+			}
+
+			if !success {
+				c.log.Error("All reconnect attempts failed — client is still disconnected")
+			}
+			c.mutex.Unlock()
+		}
+	}
+}
+
+func (c *SSEMCPClientWithRetry) Close() error {
+	c.cancel()
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if c.Client != nil {
+		return c.Client.Close()
+	}
+	return nil
+}

--- a/internal/mcp/sseClient.go
+++ b/internal/mcp/sseClient.go
@@ -158,6 +158,7 @@ func (c *SSEMCPClientWithRetry) sharedReconnect(ctx context.Context) error {
 		var success bool
 		var err error
 
+	reconnectLoop:
 		for attempt := 1; attempt <= maxReconnectAttempts; attempt++ {
 			err = c.connect()
 			if err == nil {
@@ -171,7 +172,7 @@ func (c *SSEMCPClientWithRetry) sharedReconnect(ctx context.Context) error {
 			case <-time.After(time.Duration(attempt) * baseBackoffDuration):
 			case <-c.ctx.Done():
 				err = c.ctx.Err()
-				break
+				break reconnectLoop
 			}
 		}
 

--- a/internal/mcp/sseClient.go
+++ b/internal/mcp/sseClient.go
@@ -117,6 +117,7 @@ func (c *SSEMCPClientWithRetry) connect() error {
 	initReq := mcp.InitializeRequest{}
 	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
 	if _, err = sseClient.Initialize(c.ctx, initReq); err != nil {
+		_ = sseClient.Close()
 		return err
 	}
 

--- a/internal/mcp/sseClient.go
+++ b/internal/mcp/sseClient.go
@@ -99,16 +99,18 @@ func (c *SSEMCPClientWithRetry) connect() error {
 
 	if c.Client != nil {
 		if err := c.Client.Close(); err != nil {
-			return err
+			c.log.WarnKV("Failed to close old client during reconnect", "error", err)
 		}
 	}
 
 	sseClient, err := client.NewSSEMCPClient(c.serverAddr)
 	if err != nil {
+		_ = sseClient.Close()
 		return err
 	}
 
 	if err = sseClient.Start(c.ctx); err != nil {
+		_ = sseClient.Close()
 		return err
 	}
 

--- a/internal/mcp/sseClient.go
+++ b/internal/mcp/sseClient.go
@@ -170,6 +170,7 @@ func (c *SSEMCPClientWithRetry) sharedReconnect(ctx context.Context) error {
 			select {
 			case <-time.After(time.Duration(attempt) * baseBackoffDuration):
 			case <-c.ctx.Done():
+				err = c.ctx.Err()
 				break
 			}
 		}


### PR DESCRIPTION
Replaces the default SSE MCP client with a custom wrapper that adds automatic retry and re-connection logic. When a transport error occurs during a CallTool invocation, the client attempts to reconnect and retry the call once. For all other errors, it simply returns the original error.

**Related Issues:** 
#62 
#56


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced enhanced client connectivity with automatic reconnection and retry capabilities for improved reliability when using SSE mode.
  * Added support for automatic retry of failed requests due to transport errors, reducing manual intervention during network disruptions.

* **Bug Fixes**
  * Improved handling of connection errors to ensure smoother client operation and fewer interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->