### PR TITLE
fix: ensure full config is parsed when using mcpServers field

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -116,6 +116,9 @@ func LoadConfig(configFile string, logger *logging.Logger) (*Config, error) {
 		}
 
 		if len(cfg.MCPServers) > 0 {
+			if len(cfg.Servers) > 0 && logger != nil {
+				logger.WarnKV("Both 'servers' and 'mcpServers' fields found in config, 'mcpServers' will take precedence", "servers_count", len(cfg.Servers), "mcpServers_count", len(cfg.MCPServers))
+			}
 			cfg.Servers = cfg.MCPServers
 		}
 


### PR DESCRIPTION
Fixes an issue where using the `mcpServers` field in the config file would prevent other fields from being parsed due to early short-circuiting.

Now the config is always fully unmarshaled into the `Config` struct, and if `mcpServers` is present, it is assigned to Servers to maintain compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified configuration loading by consolidating MCP servers settings into the main configuration.
  * Enhanced logging to clearly indicate the number of MCP servers loaded and precedence handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->