### PR TITLE
Feature- Added Thread and User Context, Unique tool name

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -277,7 +277,7 @@ func processSingleMCPServer(
 
 	// Create client instance (assuming HTTP/SSE based on simplified config)
 	// Use mcp.NewClient from the internal package
-	mcpClient, err := createMCPClient(serverLogger, serverConf, mcpLoggerStd)
+	mcpClient, err := createMCPClient(serverLogger, serverConf, serverName, mcpLoggerStd)
 	if err != nil {
 		*failedServers = append(*failedServers, serverName+fmt.Sprintf("(create: %s)", err))
 		return
@@ -352,7 +352,7 @@ func processSingleMCPServer(
 			serverLogger.Debug("    Tool '%s' is not in allow list, skipping", toolDef.Name)
 			continue
 		}
-		toolName := toolDef.Name
+		toolName := fmt.Sprintf("%s_%s", serverName, toolDef.Name)
 		if _, exists := discoveredTools[toolName]; !exists {
 			var inputSchemaMap map[string]interface{}
 			// Marshal the ToolInputSchema struct to JSON bytes
@@ -394,7 +394,7 @@ func processSingleMCPServer(
 
 // createMCPClient creates an MCP client based on configuration
 // Use mcp.Client and mcp.NewClient from the internal mcp package
-func createMCPClient(logger *logging.Logger, serverConf config.MCPServerConfig, _ *log.Logger) (*mcp.Client, error) {
+func createMCPClient(logger *logging.Logger, serverConf config.MCPServerConfig, serverName string, _ *log.Logger) (*mcp.Client, error) {
 	// Check if this is a URL-based (HTTP/SSE) configuration
 	if serverConf.URL != "" {
 		// Assume "sse" transport by default for HTTP-based connections
@@ -405,7 +405,7 @@ func createMCPClient(logger *logging.Logger, serverConf config.MCPServerConfig, 
 		logger.InfoKV("Creating MCP client", "transport", transport, "address", serverConf.URL)
 
 		// Use the imported mcp.NewClient from internal/mcp/client.go with structured logger
-		mcpClient, createErr := mcp.NewClient(transport, serverConf.URL, nil, nil, logger)
+		mcpClient, createErr := mcp.NewClient(transport, serverConf.URL, serverName, nil, nil, logger)
 		if createErr != nil {
 			logger.Error("Failed to create MCP client for URL %s: %v", serverConf.URL, createErr)
 			// Create a domain-specific error with additional context
@@ -445,7 +445,7 @@ func createMCPClient(logger *logging.Logger, serverConf config.MCPServerConfig, 
 
 		// Create the MCP client
 		logger.DebugKV("Executing command", "command", serverConf.Command, "args", serverConf.Args, "env", env)
-		mcpClient, createErr := mcp.NewClient(transport, serverConf.Command, serverConf.Args, env, logger)
+		mcpClient, createErr := mcp.NewClient(transport, serverConf.Command, serverName,  serverConf.Args, env, logger)
 		if createErr != nil {
 			logger.Error("Failed to create MCP client: %v", createErr)
 			// Create a domain-specific error with additional context

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -445,7 +445,7 @@ func createMCPClient(logger *logging.Logger, serverConf config.MCPServerConfig, 
 
 		// Create the MCP client
 		logger.DebugKV("Executing command", "command", serverConf.Command, "args", serverConf.Args, "env", env)
-		mcpClient, createErr := mcp.NewClient(transport, serverConf.Command, serverName,  serverConf.Args, env, logger)
+		mcpClient, createErr := mcp.NewClient(transport, serverConf.Command, serverName, serverConf.Args, env, logger)
 		if createErr != nil {
 			logger.Error("Failed to create MCP client: %v", createErr)
 			// Create a domain-specific error with additional context

--- a/internal/handlers/llm_mcp_bridge.go
+++ b/internal/handlers/llm_mcp_bridge.go
@@ -232,7 +232,7 @@ func NewLLMMCPBridgeFromClientsWithLogLevel(mcpClients interface{}, stdLogger *l
 
 // ProcessLLMResponse processes an LLM response, expecting a specific JSON tool call format.
 // It no longer uses natural language detection.
-func (b *LLMMCPBridge) ProcessLLMResponse(ctx context.Context, llmResponse *llms.ContentChoice, _ string) (string, error) {
+func (b *LLMMCPBridge) ProcessLLMResponse(ctx context.Context, llmResponse *llms.ContentChoice, _ string, extraArgs map[string]interface{}) (string, error) {
 	var toolCall *ToolCall
 	var err error
 	funcCall := llmResponse.FuncCall
@@ -252,7 +252,7 @@ func (b *LLMMCPBridge) ProcessLLMResponse(ctx context.Context, llmResponse *llms
 
 	if toolCall != nil {
 		// Execute the tool call
-		result, err := b.executeToolCall(ctx, toolCall)
+		result, err := b.executeToolCall(ctx, toolCall, extraArgs)
 		if err != nil {
 			// Check if it's already a domain error
 			var errorMessage string
@@ -446,7 +446,17 @@ func (b *LLMMCPBridge) getClientForTool(toolName string) mcp.MCPClientInterface 
 }
 
 // executeToolCall executes a detected tool call (using the new ToolCall struct)
-func (b *LLMMCPBridge) executeToolCall(ctx context.Context, toolCall *ToolCall) (string, error) {
+func (b *LLMMCPBridge) executeToolCall(ctx context.Context, toolCall *ToolCall, extraArgs map[string]interface{}) (string, error) {
+	for k, v := range extraArgs {
+		// Add any extra arguments to the tool call args
+		if toolCall.Args == nil {
+			toolCall.Args = make(map[string]interface{})
+		}
+		toolCall.Args[k] = v
+	}
+	b.logger.DebugKV("Executing tool call",
+		"tool", toolCall.Tool,
+		"args", fmt.Sprintf("%v", toolCall.Args))
 	client := b.getClientForTool(toolCall.Tool)
 	if client == nil {
 		b.logger.ErrorKV("No MCP client available", "tool", toolCall.Tool)

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -29,7 +29,7 @@ type Client struct {
 	logger      *logging.Logger
 	client      client.MCPClient
 	serverAddr  string
-	serverName string
+	serverName  string
 	initialized bool // Track if the client has been successfully initialized
 
 	closeOnce sync.Once  // Ensures close logic runs only once

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -29,6 +29,7 @@ type Client struct {
 	logger      *logging.Logger
 	client      client.MCPClient
 	serverAddr  string
+	serverName string
 	initialized bool // Track if the client has been successfully initialized
 
 	closeOnce sync.Once  // Ensures close logic runs only once
@@ -36,9 +37,9 @@ type Client struct {
 }
 
 // NewClient creates a new MCP client handler.
-// For stdio transport, addressOrCommand should be the command path, and args should be provided.
-// For http/sse transports, addressOrCommand is the URL, and args is ignored.
-func NewClient(transport, addressOrCommand string, args []string, env map[string]string, stdLogger *logging.Logger) (*Client, error) {
+// For stdio mode, addressOrCommand should be the command path, and args should be provided.
+// For http/sse modes, addressOrCommand is the URL, and args is ignored.
+func NewClient(transport, addressOrCommand string, serverName string, args []string, env map[string]string, stdLogger *logging.Logger) (*Client, error) {
 	// Determine log level from environment variable
 	logLevel := logging.LevelInfo // Default to INFO
 	if envLevel := os.Getenv("LOG_LEVEL"); envLevel != "" {
@@ -106,6 +107,7 @@ func NewClient(transport, addressOrCommand string, args []string, env map[string
 		logger:      mcpLogger,
 		client:      mcpClient,
 		serverAddr:  addressOrCommand,
+		serverName:  serverName,
 		initialized: false,
 	}
 
@@ -170,6 +172,12 @@ func (c *Client) CallTool(ctx context.Context, toolName string, args map[string]
 	}
 
 	c.logger.InfoKV("Calling tool", "tool", toolName, "server", c.serverAddr)
+	prefix := c.serverName + "_"
+	c.logger.DebugKV("Tool name prefix", "prefix", prefix)
+	if strings.HasPrefix(toolName, prefix) {
+		toolName = strings.TrimPrefix(toolName, prefix)
+		c.logger.DebugKV("Stripped prefix from tool name", "original", toolName, "stripped", toolName)
+	}
 
 	// Create a proper CallToolRequest
 	req := mcp.CallToolRequest{}

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -175,8 +175,9 @@ func (c *Client) CallTool(ctx context.Context, toolName string, args map[string]
 	prefix := c.serverName + "_"
 	c.logger.DebugKV("Tool name prefix", "prefix", prefix)
 	if strings.HasPrefix(toolName, prefix) {
+		originalToolName := toolName
 		toolName = strings.TrimPrefix(toolName, prefix)
-		c.logger.DebugKV("Stripped prefix from tool name", "original", toolName, "stripped", toolName)
+		c.logger.DebugKV("Stripped prefix from tool name", "original", originalToolName, "stripped", toolName)
 	}
 
 	// Create a proper CallToolRequest

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -38,13 +38,13 @@ type Client struct {
 
 // Message represents a message in the conversation history
 type Message struct {
-	Role            string    // "user", "assistant", or "tool"
-	Content         string    // The message content
-	Timestamp       time.Time // When the message was sent/received
-	SlackTimestamp  string    // Slack's timestamp format (string)
-	UserID          string
-	RealName        string
-	Email           string
+	Role           string    // "user", "assistant", or "tool"
+	Content        string    // The message content
+	Timestamp      time.Time // When the message was sent/received
+	SlackTimestamp string    // Slack's timestamp format (string)
+	UserID         string
+	RealName       string
+	Email          string
 }
 
 // NewClient creates a new Slack client instance.
@@ -295,13 +295,13 @@ func (c *Client) addToHistory(channelID, threadTS, timestamp, role, content, use
 
 	// Add the new message
 	message := Message{
-		Role:      role,
-		Content:   content,
-		Timestamp: time.Now(),
+		Role:           role,
+		Content:        content,
+		Timestamp:      time.Now(),
 		SlackTimestamp: timestamp,
-		UserID:    userID,
-		RealName:  realName,
-		Email:     email,
+		UserID:         userID,
+		RealName:       realName,
+		Email:          email,
 	}
 	history = append(history, message)
 

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	// "github.com/json-iterator/go/extra"
 	"github.com/slack-go/slack/slackevents"
 	"github.com/slack-go/slack/socketmode"
 
@@ -257,13 +256,12 @@ func (c *Client) handleEventMessage(event slackevents.EventsAPIEvent) {
 
 			if isDirectMessage && isValidUser && isNotEdited && !isBot {
 				c.logger.InfoKV("Received direct message in channel", "channel", ev.Channel, "user", ev.User, "text", ev.Text, "ThreadTS", ev.ThreadTimeStamp)
-				// Add to message history
 				profile, err := c.userFrontend.GetUserInfo(ev.User)
 				if err != nil {
 					c.logger.WarnKV("Failed to get user info", "user", ev.User, "error", err)
 					profile = &UserProfile{userId: ev.User, realName: "Unknown", email: ""}
 				}
-				// c.addToHistory(ev.Channel, ev.ThreadTimeStamp, "user", ev.Text, profile.userId, profile.realName, profile.email)
+
 				parentTS := ev.ThreadTimeStamp
 				if parentTS == "" {
 					parentTS = ev.TimeStamp // Use the original message timestamp if no thread

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -379,7 +379,6 @@ func (c *Client) handleUserPrompt(userPrompt, channelID, threadTS string, profil
 	// Show a temporary "typing" indicator
 	c.userFrontend.SendMessage(channelID, threadTS, thinkingMessage)
 
-
 	if !c.llmMCPBridge.UseAgent {
 		// Prepare the final prompt with custom prompt as system instruction
 		var finalPrompt string
@@ -496,7 +495,7 @@ func (c *Client) processLLMResponseAndReply(llmResponse *llms.ContentChoice, use
 
 		// Add history
 		c.addToHistory(channelID, threadTS, "assistant", llmResponse.Content, "", "", "") // Original LLM response (tool call JSON)
-		c.addToHistory(channelID, threadTS, "tool", finalResponse, "", "", "")    // Tool execution result
+		c.addToHistory(channelID, threadTS, "tool", finalResponse, "", "", "")            // Tool execution result
 
 		c.logger.DebugKV("Re-prompting LLM", "prompt", rePrompt)
 

--- a/internal/slack/stdioClient.go
+++ b/internal/slack/stdioClient.go
@@ -90,7 +90,7 @@ func (client StdioClient) IsBotUser(userID string) bool {
 }
 
 func (client StdioClient) GetThreadReplies(channelID, threadTS string) ([]slack.Message, error) {
-    return []slack.Message{}, nil
+	return []slack.Message{}, nil
 }
 
 func (client StdioClient) GetUserInfo(userID string) (*UserProfile, error) {

--- a/internal/slack/stdioClient.go
+++ b/internal/slack/stdioClient.go
@@ -94,10 +94,14 @@ func (client StdioClient) GetThreadReplies(channelID, threadTS string) ([]slack.
 }
 
 func (client StdioClient) GetUserInfo(userID string) (*UserProfile, error) {
+	currentUser, err := user.Current()
+	if err != nil {
+		return nil, fmt.Errorf("while getting current user: %w", err)
+	}
 	return &UserProfile{
 		userId:   userID,
-		realName: "Real Name",
-		email:    "user@example.com",
+		realName: currentUser.Name,
+		email:    "",
 	}, nil
 }
 

--- a/internal/slack/stdioClient.go
+++ b/internal/slack/stdioClient.go
@@ -93,6 +93,14 @@ func (client StdioClient) GetThreadReplies(channelID, threadTS string) ([]slack.
     return []slack.Message{}, nil
 }
 
+func (client StdioClient) GetUserInfo(userID string) (*UserProfile, error) {
+	return &UserProfile{
+		userId:   userID,
+		realName: "Real Name",
+		email:    "user@example.com",
+	}, nil
+}
+
 func (client StdioClient) SendMessage(channelID, threadTS, text string) {
 	messages := []string{
 		"----- SEND MESSAGE -----\n",
@@ -105,26 +113,4 @@ func (client StdioClient) SendMessage(channelID, threadTS, text string) {
 			client.logger.ErrorKV("While writing message to output", "error", err)
 		}
 	}
-}
-
-func (client StdioClient) GetUserInfo(userID string) (*slack.User, error) {
-	currentUser, err := user.Current()
-	if err != nil {
-		return nil, fmt.Errorf("while getting current user: %w", err)
-	}
-
-	return &slack.User{
-		ID:       "xxx",
-		TeamID:   "",
-		Name:     currentUser.Username,
-		Deleted:  false,
-		Color:    "",
-		RealName: "",
-		TZ:       "",
-		TZLabel:  "",
-		TZOffset: 0,
-		Profile: slack.UserProfile{
-			DisplayName: currentUser.Name,
-		},
-	}, nil
 }

--- a/internal/slack/stdioClient.go
+++ b/internal/slack/stdioClient.go
@@ -89,6 +89,10 @@ func (client StdioClient) IsBotUser(userID string) bool {
 	return false
 }
 
+func (client StdioClient) GetThreadReplies(channelID, threadTS string) ([]slack.Message, error) {
+    return []slack.Message{}, nil
+}
+
 func (client StdioClient) SendMessage(channelID, threadTS, text string) {
 	messages := []string{
 		"----- SEND MESSAGE -----\n",

--- a/internal/slack/userFrontend.go
+++ b/internal/slack/userFrontend.go
@@ -126,7 +126,7 @@ func (slackClient *SlackClient) GetThreadReplies(channelID, threadTS string) ([]
 	}
 	replies, _, _, err := slackClient.GetConversationReplies(&slack.GetConversationRepliesParameters{
 		ChannelID: channelID,
-		Timestamp:  threadTS,
+		Timestamp: threadTS,
 	})
 	if err != nil {
 		return nil, customErrors.WrapSlackError(err, "fetch_thread_replies_failed", "Failed to fetch thread replies")
@@ -148,7 +148,7 @@ func (slackClient *SlackClient) GetUserInfo(userID string) (*UserProfile, error)
 		return nil, customErrors.WrapSlackError(err, "fetch_user_profile_failed", "Failed to fetch user profile")
 	}
 	profile := &UserProfile{
-		userId:  userID,
+		userId:   userID,
 		realName: slackProfile.RealName,
 		email:    slackProfile.Email,
 	}

--- a/internal/slack/userFrontend.go
+++ b/internal/slack/userFrontend.go
@@ -24,6 +24,7 @@ type UserFrontend interface {
 	GetLogger() *logging.Logger
 	SendMessage(channelID, threadTS, text string)
 	GetUserInfo(userID string) (*slack.User, error)
+	GetThreadReplies(channelID, threadTS string) ([]slack.Message, error)
 }
 
 func getLogLevel(stdLogger *logging.Logger) logging.LogLevel {
@@ -117,6 +118,22 @@ func (slackClient *SlackClient) GetUserInfo(userID string) (*slack.User, error) 
 		return nil, fmt.Errorf("while getting user info for %s: %w", userID, err)
 	}
 	return user, nil
+}
+
+func (slackClient *SlackClient) GetThreadReplies(channelID, threadTS string) ([]slack.Message, error) {
+	if channelID == "" || threadTS == "" {
+		return nil, fmt.Errorf("channelID and threadTS must be provided")
+	}
+
+	replies, _, _,  err := slackClient.GetConversationReplies(&slack.GetConversationRepliesParameters{
+		ChannelID: channelID,
+		Timestamp:  threadTS,
+	})
+	if err != nil {
+		return nil, customErrors.WrapSlackError(err, "fetch_thread_replies_failed", "Failed to fetch thread replies")
+	}
+
+	return replies, nil
 }
 
 // SendMessage sends a message back to Slack, replying in a thread if threadTS is provided.


### PR DESCRIPTION
* Added Thread context by fetching replies automatically based on the event and add to context history
* Added User context and cache by fetching user info from slack api
* Added a prefix as server name to the tools to overcome the issue of servers having same tool names
* Changed context history from channel based to thread based
* Added extra arguments channel id and thread timestamp to the tools, to easily summarize the thread without slack mcp server asking for channel id and thread timestamp again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Slack integration by associating message history with both channel and thread, enabling better context management for threaded conversations.
  * Message history now includes user details such as user ID, real name, and email for richer conversation context.
  * Slack thread replies are synchronized into message history, ensuring complete conversation tracking.
  * User profile information is cached for faster access and reduced API calls.
  * Added support for passing extra arguments through the system to enhance tool execution flexibility.
  * Introduced server name parameter to namespace tools and clients, improving tool identification across multiple servers.

* **Enhancements**
  * Tool names from external servers are now prefixed with the server name, providing clearer tool identification and avoiding naming conflicts.
  * Additional context and user metadata are passed through the system, improving the accuracy and personalization of responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->