### PR TITLE
Feat/backup (#18)

### DIFF
--- a/.github/workflows/claude-org.yml
+++ b/.github/workflows/claude-org.yml
@@ -1,0 +1,68 @@
+name: Claude Code Org
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    env:
+      # Define authorized users (space-separated for easy contains() check)
+      # The surrounding spaces prevent partial matches (e.g., "admin" won't match "badmin")
+      AUTHORIZED_USERS: ' yekkhan-liftoff wyangsun tommynguyen-vungle '
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(env.AUTHORIZED_USERS, format(' {0} ', github.event.comment.user.login))) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(env.AUTHORIZED_USERS, format(' {0} ', github.event.comment.user.login))) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(env.AUTHORIZED_USERS, format(' {0} ', github.event.review.user.login))) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(env.AUTHORIZED_USERS, format(' {0} ', github.event.issue.user.login)))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+          
+          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
+          # model: "claude-opus-4-20250514"
+          
+          # Optional: Customize the trigger phrase (default: @claude)
+          # trigger_phrase: "/claude"
+          
+          # Optional: Trigger when specific user is assigned to an issue
+          # assignee_trigger: "claude-bot"
+          
+          # Optional: Allow Claude to run specific commands
+          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
+          
+          # Optional: Add custom instructions for Claude to customize its behavior for your project
+          # custom_instructions: |
+          #   Follow our coding standards
+          #   Ensure all new code has tests
+          #   Use TypeScript for new files
+          
+          # Optional: Custom environment variables for Claude
+          # claude_env: |
+          #   NODE_ENV: test
+

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ ehthumbs.db
 Thumbs.db
 
 mcp-servers.json
+config.json

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -560,12 +560,6 @@ func startSlackClient(logger *logging.Logger, mcpClients map[string]*mcp.Client,
 						"type":        "string",
 						"description": "The search query to find relevant information",
 					},
-					"limit": map[string]interface{}{
-						"type":        "integer",
-						"description": "Maximum number of results to return (default: 5, max: 20)",
-						"minimum":     1,
-						"maximum":     20,
-					},
 				},
 				"required": []string{"query"},
 			},
@@ -721,7 +715,6 @@ func handleRAGSearch(query string) {
 	// Use the RAG client to search
 	result, err := ragClient.CallTool(ctx, "rag_search", map[string]interface{}{
 		"query": query,
-		"limit": 5,
 	})
 	if err != nil {
 		fmt.Printf("Error during search: %v\n", err)

--- a/helm-chart/slack-mcp-client/templates/deployment.yaml
+++ b/helm-chart/slack-mcp-client/templates/deployment.yaml
@@ -42,6 +42,11 @@ spec:
             - secretRef:
                 name: {{ include "slack-mcp-client.fullname" . }}
                 optional: false
+            {{- if and .Values.secret.enabled (ne .Values.secret.name "") }}
+            - secretRef:
+                name: {{ .Values.secret.name }}
+                optional: false
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if or .Values.configMap.create .Values.configMap.name }}

--- a/helm-chart/slack-mcp-client/values.yaml
+++ b/helm-chart/slack-mcp-client/values.yaml
@@ -77,3 +77,12 @@ configMap:
   #        }
   #      }
   #    }
+
+# If you want to use external secret for the environment variables, you can use the following:
+# Example:
+# secret:
+#   enabled: true
+#   name: "my-secret"
+secret:
+  enabled: false
+  name: ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,10 +74,12 @@ func (mcp *MCPServerConfig) GetTransport() string {
 	}
 	if mcp.Command != "" {
 		return "stdio" // Default: if command is specified, use stdio
+
 	}
 	if mcp.URL != "" {
 		return "sse" // Default: if URL is specified, use sse
 	}
+
 	return "stdio" // Fallback default
 }
 
@@ -104,13 +106,19 @@ type RAGConfig struct {
 }
 
 // RAGProviderConfig contains RAG provider-specific settings
+// TODO: Refactor this to use a common interface for all RAG providers, can use environment variables to configure the different providers
 type RAGProviderConfig struct {
-	DatabasePath     string `json:"databasePath,omitempty"`     // Simple provider: path to JSON database
-	IndexName        string `json:"indexName,omitempty"`        // OpenAI provider: vector store name
-	VectorStoreID    string `json:"vectorStoreId,omitempty"`    // OpenAI provider: existing vector store ID
-	Dimensions       int    `json:"dimensions,omitempty"`       // OpenAI provider: embedding dimensions
-	SimilarityMetric string `json:"similarityMetric,omitempty"` // OpenAI provider: similarity metric
-	MaxResults       int    `json:"maxResults,omitempty"`       // OpenAI provider: maximum search results
+	DatabasePath             string  `json:"databasePath,omitempty"`             // Simple provider: path to JSON database
+	IndexName                string  `json:"indexName,omitempty"`                // OpenAI provider: vector store name
+	VectorStoreID            string  `json:"vectorStoreId,omitempty"`            // OpenAI provider: existing vector store ID
+	Dimensions               int     `json:"dimensions,omitempty"`               // OpenAI provider: embedding dimensions
+	SimilarityMetric         string  `json:"similarityMetric,omitempty"`         // OpenAI provider: similarity metric
+	MaxResults               int     `json:"maxResults,omitempty"`               // OpenAI provider: maximum search results
+	ScoreThreshold           float64 `json:"scoreThreshold,omitempty"`           // OpenAI provider: score threshold
+	RewriteQuery             bool    `json:"rewriteQuery,omitempty"`             // OpenAI provider: rewrite query
+	VectorStoreNameRegex     string  `json:"vectorStoreNameRegex,omitempty"`     // OpenAI provider: vector store name regex
+	VectorStoreMetadataKey   string  `json:"vectorStoreMetadataKey,omitempty"`   // OpenAI provider: vector store metadata key
+	VectorStoreMetadataValue string  `json:"vectorStoreMetadataValue,omitempty"` // OpenAI provider: vector store metadata value
 }
 
 // MonitoringConfig contains monitoring and observability settings
@@ -139,7 +147,7 @@ type RetryConfig struct {
 	MCPReconnectBackoff  string `json:"mcpReconnectBackoff,omitempty"`  // MCP reconnection backoff (default: "1s")
 }
 
-// ReloadConfig contains settings for periodic application reload
+// ReloadConfig contains signal-based reload configuration
 type ReloadConfig struct {
 	Enabled  bool   `json:"enabled,omitempty"`  // Enable periodic reload (default: false)
 	Interval string `json:"interval,omitempty"` // Reload interval (default: "30m")
@@ -256,12 +264,6 @@ func (c *Config) ApplyDefaults() {
 	if c.Retry.MCPReconnectBackoff == "" {
 		c.Retry.MCPReconnectBackoff = "1s"
 	}
-
-	// Reload defaults
-	if c.Reload.Interval == "" {
-		c.Reload.Interval = "30m"
-	}
-
 	// Monitoring defaults
 	c.Monitoring.Enabled = true // Default to enabled
 	if c.Monitoring.MetricsPort == 0 {

--- a/internal/handlers/llm_mcp_bridge.go
+++ b/internal/handlers/llm_mcp_bridge.go
@@ -582,8 +582,8 @@ func (b *LLMMCPBridge) CallLLM(providerName, prompt, contextHistory string) (*ll
 	options := llm.ProviderOptions{
 		// Model: Let the provider use its configured default or handle overrides if needed.
 		// Model: c.cfg.OpenAIModelName, // Example: If you still want a global default hint
-		Temperature: 0.7,  // Consider making configurable
-		MaxTokens:   2048, // Consider making configurable
+		Temperature: 0.4,   // Consider making configurable
+		MaxTokens:   10240, // Consider making configurable
 	}
 
 	if !b.useNativeTools {

--- a/internal/rag/client.go
+++ b/internal/rag/client.go
@@ -4,7 +4,6 @@ package rag
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 )
 
@@ -12,7 +11,6 @@ import (
 // This allows the LLM-MCP bridge to treat RAG as a regular MCP tool
 type Client struct {
 	provider VectorProvider
-	maxDocs  int // Maximum documents to return in a single call
 }
 
 // NewClient creates a new RAG client with simple provider (legacy compatibility)
@@ -29,13 +27,11 @@ func NewClient(ragDatabase string) *Client {
 		_ = simpleProvider.Initialize(context.Background())
 		return &Client{
 			provider: simpleProvider,
-			maxDocs:  10,
 		}
 	}
 
 	return &Client{
 		provider: provider,
-		maxDocs:  10,
 	}
 }
 
@@ -54,7 +50,6 @@ func NewClientWithProvider(providerType string, config map[string]interface{}) (
 
 	return &Client{
 		provider: provider,
-		maxDocs:  20, // Higher default for vector stores
 	}, nil
 }
 
@@ -84,32 +79,8 @@ func (c *Client) handleRAGSearch(ctx context.Context, args map[string]interface{
 		return "", err
 	}
 
-	// Extract optional limit parameter
-	limit := c.maxDocs
-	if limitParam, exists := args["limit"]; exists {
-		if limitInt, ok := limitParam.(int); ok {
-			limit = limitInt
-		} else if limitFloat, ok := limitParam.(float64); ok {
-			limit = int(limitFloat)
-		} else if limitStr, ok := limitParam.(string); ok {
-			if parsed, parseErr := strconv.Atoi(limitStr); parseErr == nil {
-				limit = parsed
-			}
-		}
-	}
-
-	// Clamp limit to reasonable bounds
-	if limit <= 0 {
-		limit = 3
-	}
-	if limit > 20 {
-		limit = 20
-	}
-
 	// Perform search using the provider
-	results, err := c.provider.Search(ctx, query, SearchOptions{
-		Limit: limit,
-	})
+	results, err := c.provider.Search(ctx, query, SearchOptions{})
 	if err != nil {
 		return "", fmt.Errorf("search failed: %w", err)
 	}

--- a/internal/rag/openai_provider.go
+++ b/internal/rag/openai_provider.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -14,10 +15,15 @@ import (
 
 // OpenAIConfig holds configuration for the OpenAI provider
 type OpenAIConfig struct {
-	APIKey          string
-	VectorStoreID   string // Optional: reuse existing vector store
-	VectorStoreName string // Name for the vector store (default: "Knowledge Base")
-	MaxResults      int    // Default: 20
+	APIKey                   string
+	VectorStoreID            string  // Optional: reuse existing vector store
+	VectorStoreName          string  // Name for the vector store (default: "Knowledge Base")
+	MaxResults               int64   // Default: 20
+	ScoreThreshold           float64 // Default: 0.5
+	RewriteQuery             bool    // Whether to rewrite the query
+	VectorStoreNameRegex     string  // Regex for the vector store name
+	VectorStoreMetadataKey   string  // Key for the vector store metadata
+	VectorStoreMetadataValue string  // Value for the vector store metadata
 }
 
 // OpenAIProvider implements VectorProvider using OpenAI's VectorStore API with 2025 updates
@@ -29,9 +35,10 @@ type OpenAIProvider struct {
 
 // NewOpenAIProvider creates a new OpenAI vector provider instance
 func NewOpenAIProvider(config map[string]interface{}) (VectorProvider, error) {
+	defaultMaxResults := int64(20)
+
 	cfg := OpenAIConfig{
-		MaxResults:      20,
-		VectorStoreName: "Knowledge Base",
+		MaxResults: defaultMaxResults,
 	}
 
 	// Extract configuration
@@ -54,8 +61,30 @@ func NewOpenAIProvider(config map[string]interface{}) (VectorProvider, error) {
 		cfg.VectorStoreName = vectorStoreName
 	}
 
-	if maxResults, ok := config["max_results"].(int); ok {
-		cfg.MaxResults = maxResults
+	if scoreThreshold, ok := config["score_threshold"].(float64); ok {
+		cfg.ScoreThreshold = scoreThreshold
+	}
+
+	if rewriteQuery, ok := config["rewrite_query"].(bool); ok {
+		cfg.RewriteQuery = rewriteQuery
+	}
+
+	if vectorStoreNameRegex, ok := config["vector_store_name_regex"].(string); ok {
+		cfg.VectorStoreNameRegex = vectorStoreNameRegex
+	}
+
+	if vectorStoreMetadataKey, ok := config["vs_metadata_key"].(string); ok {
+		cfg.VectorStoreMetadataKey = vectorStoreMetadataKey
+	}
+
+	if vectorStoreMetadataValue, ok := config["vs_metadata_value"].(string); ok {
+		cfg.VectorStoreMetadataValue = vectorStoreMetadataValue
+	}
+
+	if maxResults, ok := config["max_results"].(float64); ok {
+		cfg.MaxResults = int64(maxResults)
+	} else if maxResultsInt, ok := config["max_results"].(int); ok {
+		cfg.MaxResults = int64(maxResultsInt)
 	}
 
 	// Create OpenAI client
@@ -81,34 +110,34 @@ func (o *OpenAIProvider) Initialize(ctx context.Context) error {
 		o.vectorStoreID = vectorStore.ID
 		fmt.Printf("[RAG] OpenAI: Using existing vector store '%s' with ID: %s\n", vectorStore.Name, o.vectorStoreID)
 	} else {
-		// Search for existing vector store by name first
-		existingVectorStore, err := o.findVectorStoreByName(ctx, o.config.VectorStoreName)
-		if err != nil {
-			return fmt.Errorf("failed to search for vector store: %w", err)
-		}
-
-		if existingVectorStore != nil {
-			// Found existing vector store
+		if o.config.VectorStoreName != "" {
+			// Search for existing vector store by name first
+			existingVectorStore, err := o.findVectorStoreByName(ctx, o.config.VectorStoreName)
+			if err != nil {
+				return fmt.Errorf("failed to search for vector store: %w", err)
+			}
 			o.vectorStoreID = existingVectorStore.ID
 			fmt.Printf("[RAG] OpenAI: Found existing vector store '%s' with ID: %s\n", o.config.VectorStoreName, o.vectorStoreID)
 		} else {
-			// Create new vector store
-			vectorStore, err := o.client.VectorStores.New(ctx, openai.VectorStoreNewParams{
-				Name: openai.String(o.config.VectorStoreName),
-			})
-			if err != nil {
-				return fmt.Errorf("failed to create vector store: %w", err)
-			}
-			o.vectorStoreID = vectorStore.ID
-			fmt.Printf("[RAG] OpenAI: Created new vector store '%s' with ID: %s\n", o.config.VectorStoreName, o.vectorStoreID)
+			// Dynamic Vector Store
+			fmt.Printf("[RAG] OpenAI: Using dynamic vector store\n")
 		}
 	}
-
 	return nil
 }
 
 // IngestFile uploads a file to the OpenAI vector store
 func (o *OpenAIProvider) IngestFile(ctx context.Context, filePath string, metadata map[string]string) (string, error) {
+	// Check if vector store ID is empty
+	if o.vectorStoreID == "" {
+		// Use dynamic vector store
+		fmt.Printf("[RAG] OpenAI: Using dynamic vector store\n")
+		vectorStoreID, err := o.searchVectorStore(ctx, o.config.VectorStoreNameRegex)
+		if err != nil {
+			return "", fmt.Errorf("failed to search vector store: %w", err)
+		}
+		o.vectorStoreID = vectorStoreID
+	}
 	// Open the file for upload
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -180,6 +209,15 @@ func (o *OpenAIProvider) IngestFiles(ctx context.Context, filePaths []string, me
 
 // DeleteFile removes a file from the vector store
 func (o *OpenAIProvider) DeleteFile(ctx context.Context, fileID string) error {
+	if o.vectorStoreID == "" {
+		// Use dynamic vector store
+		fmt.Printf("[RAG] OpenAI: Using dynamic vector store\n")
+		vectorStoreID, err := o.searchVectorStore(ctx, o.config.VectorStoreNameRegex)
+		if err != nil {
+			return fmt.Errorf("failed to search vector store: %w", err)
+		}
+		o.vectorStoreID = vectorStoreID
+	}
 	// Remove from vector store first
 	_, err := o.client.VectorStores.Files.Delete(ctx, o.vectorStoreID, fileID)
 	if err != nil {
@@ -198,6 +236,15 @@ func (o *OpenAIProvider) DeleteFile(ctx context.Context, fileID string) error {
 
 // ListFiles lists all files in the vector store
 func (o *OpenAIProvider) ListFiles(ctx context.Context, limit int) ([]FileInfo, error) {
+	if o.vectorStoreID == "" {
+		// Use dynamic vector store
+		fmt.Printf("[RAG] OpenAI: Using dynamic vector store\n")
+		vectorStoreID, err := o.searchVectorStore(ctx, o.config.VectorStoreNameRegex)
+		if err != nil {
+			return nil, fmt.Errorf("failed to search vector store: %w", err)
+		}
+		o.vectorStoreID = vectorStoreID
+	}
 	// List vector store files
 	vsFiles, err := o.client.VectorStores.Files.List(ctx, o.vectorStoreID, openai.VectorStoreFileListParams{
 		Limit: openai.Int(int64(limit)),
@@ -232,10 +279,26 @@ func (o *OpenAIProvider) ListFiles(ctx context.Context, limit int) ([]FileInfo, 
 func (o *OpenAIProvider) Search(ctx context.Context, query string, options SearchOptions) ([]SearchResult, error) {
 	fmt.Printf("[RAG] OpenAI: Vector Store search for query '%s' (vector_store: %s)\n", query, o.vectorStoreID)
 
+	// Check if vector store ID is empty
+	if o.vectorStoreID == "" {
+		// Use dynamic vector store
+		fmt.Printf("[RAG] OpenAI: Using dynamic vector store\n")
+		vectorStoreID, err := o.searchVectorStore(ctx, o.config.VectorStoreNameRegex)
+		if err != nil {
+			return nil, fmt.Errorf("failed to search vector store: %w", err)
+		}
+		o.vectorStoreID = vectorStoreID
+	}
+
 	// Set up search parameters
-	limit := options.Limit
-	if limit <= 0 {
-		limit = o.config.MaxResults
+	limit := o.config.MaxResults
+	if o.config.MaxResults <= 0 {
+		limit = 20
+	}
+
+	scoreThreshold := o.config.ScoreThreshold
+	if scoreThreshold <= 0 {
+		scoreThreshold = 0.5 // Use the default value defined in OpenAIConfig
 	}
 
 	// Use OpenAI's Vector Store Search API with proper union type
@@ -243,7 +306,12 @@ func (o *OpenAIProvider) Search(ctx context.Context, query string, options Searc
 		Query: openai.VectorStoreSearchParamsQueryUnion{
 			OfString: openai.String(query),
 		},
-		MaxNumResults: openai.Int(int64(limit)),
+		MaxNumResults: openai.Int(limit),
+		RewriteQuery:  openai.Bool(o.config.RewriteQuery),
+		RankingOptions: openai.VectorStoreSearchParamsRankingOptions{
+			ScoreThreshold: openai.Float(scoreThreshold),
+			Ranker:         "auto",
+		},
 	}
 
 	searchResults, err := o.client.VectorStores.Search(ctx, o.vectorStoreID, searchParams)
@@ -300,6 +368,15 @@ func (o *OpenAIProvider) Search(ctx context.Context, query string, options Searc
 
 // GetStats returns statistics about the vector store
 func (o *OpenAIProvider) GetStats(ctx context.Context) (*VectorStoreStats, error) {
+	if o.vectorStoreID == "" {
+		// Use dynamic vector store
+		fmt.Printf("[RAG] OpenAI: Using dynamic vector store\n")
+		vectorStoreID, err := o.searchVectorStore(ctx, o.config.VectorStoreNameRegex)
+		if err != nil {
+			return nil, fmt.Errorf("failed to search vector store: %w", err)
+		}
+		o.vectorStoreID = vectorStoreID
+	}
 	// Get vector store details
 	vs, err := o.client.VectorStores.Get(ctx, o.vectorStoreID)
 	if err != nil {
@@ -348,6 +425,45 @@ func (o *OpenAIProvider) findVectorStoreByName(ctx context.Context, name string)
 	}
 
 	return nil, nil // Not found
+}
+
+func (o *OpenAIProvider) searchVectorStore(ctx context.Context, vectorStoreNameRegex string) (string, error) {
+	if vectorStoreNameRegex == "" {
+		return "", fmt.Errorf("vector store name regex cannot be empty")
+	}
+
+	foundVectorStoreID := ""
+	// to match the vector store name regex
+	vectorStores, err := o.client.VectorStores.List(ctx, openai.VectorStoreListParams{
+		Limit: openai.Int(100), // Get up to 100 vector stores to search through
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to list vector stores: %w", err)
+	}
+
+	re, err := regexp.Compile(vectorStoreNameRegex)
+	if err != nil {
+		return "", fmt.Errorf("invalid vector store name regex: %w", err)
+	}
+	for _, vs := range vectorStores.Data {
+		if re.MatchString(vs.Name) {
+			if o.config.VectorStoreMetadataKey != "" && o.config.VectorStoreMetadataValue != "" {
+				if vs.Metadata != nil && vs.Metadata[o.config.VectorStoreMetadataKey] == o.config.VectorStoreMetadataValue {
+					foundVectorStoreID = vs.ID
+					fmt.Printf("[RAG] OpenAI: Found vector store '%s' with ID: %s and metadata '%s' = '%s'\n", vs.Name, foundVectorStoreID, o.config.VectorStoreMetadataKey, o.config.VectorStoreMetadataValue)
+					break
+				}
+			} else {
+				foundVectorStoreID = vs.ID
+				fmt.Printf("[RAG] OpenAI: Found vector store '%s' with ID: %s\n", vs.Name, foundVectorStoreID)
+				break
+			}
+		}
+	}
+	if foundVectorStoreID == "" {
+		return "", fmt.Errorf("no vector store found with name matching regex: %s and metadata '%s' = '%s'", o.config.VectorStoreNameRegex, o.config.VectorStoreMetadataKey, o.config.VectorStoreMetadataValue)
+	}
+	return foundVectorStoreID, nil
 }
 
 // init registers the OpenAI provider

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -109,6 +109,21 @@ func NewClient(userFrontend UserFrontend, stdLogger *logging.Logger, mcpClients 
 				if providerSettings.MaxResults > 0 {
 					ragConfig["max_results"] = providerSettings.MaxResults
 				}
+				if providerSettings.ScoreThreshold > 0 {
+					ragConfig["score_threshold"] = providerSettings.ScoreThreshold
+				}
+				if providerSettings.RewriteQuery {
+					ragConfig["rewrite_query"] = providerSettings.RewriteQuery
+				}
+				if providerSettings.VectorStoreNameRegex != "" {
+					ragConfig["vector_store_name_regex"] = providerSettings.VectorStoreNameRegex
+				}
+				if providerSettings.VectorStoreMetadataKey != "" {
+					ragConfig["vs_metadata_key"] = providerSettings.VectorStoreMetadataKey
+				}
+				if providerSettings.VectorStoreMetadataValue != "" {
+					ragConfig["vs_metadata_value"] = providerSettings.VectorStoreMetadataValue
+				}
 				// Add OpenAI API key from LLM config or environment
 				if openaiConfig, exists := cfg.LLM.Providers["openai"]; exists && openaiConfig.APIKey != "" {
 					ragConfig["api_key"] = openaiConfig.APIKey


### PR DESCRIPTION
* PE-7012: Update README.md

* PE-7012: add image to readme

* update image link

* PE-7039: Satrun score threshold

* add content back to rag search result

* update default score threshold and max results

* Update internal/rag/openai_provider.go



* support dynamic vector store matching

* update default temperature and max tokens, will be configurable in the future

* Sync with upstream

* PE-7078: Refactor config

* Support vector store metadata filter and rewrite query

* update config for testing

* PE-7078: Remove config.json

* PE-7078: Build and push image workflow

* PE-7078: Fix build and push image workflow

* PE-7078: Fix build and push image workflow

* PE-7078: Fix build and push image workflow

* PE-7078: Fix build and push image workflow

* add permissions to build and push image workflow

* update build and push image workflow

* add Test env to release workflow

* remove testing workflow

* add TODO

* update openai provider

* update openai provider, create searchVectorStore function

* update searchVectorStore function

* update openai provider

* update openai provider

* Update Claude PR Assistant workflow

* Claude Code Review workflow

* chore(ci): update workflows, remove claude-code-review add claude-org



* ci: restrict workflow trigger to specific user



* PE-7116: Use external secret for environment variables

* Update helm-chart/slack-mcp-client/templates/deployment.yaml



* Update helm-chart/slack-mcp-client/values.yaml



* Update helm-chart/slack-mcp-client/values.yaml



* Update helm-chart/slack-mcp-client/templates/deployment.yaml



* bug fix: openai vector store tool bug

* feat(config): add ReloadConfig struct for signal-based reload settings



---------