### PR TITLE
feat: add HTTP headers support for SSE MCP server authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial setup of CI/CD pipeline
 - Basic project structure
+- Support for `httpHeaders` field for authentication
 
 ## [0.1.0] - YYYY-MM-DD
 ### Added

--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ This client enables AI models (OpenAI, Anthropic, Ollama) to interact with real 
 - **Custom MCP Servers** - Works with any MCP-compliant server
 - **Security Standards** - Implements user consent, data privacy, and tool safety requirements
 
+## Authenticating to SSE MCP Servers
+
+Authentication with Server-Sent Events (SSE) MCP servers can be achieved using the following setup:
+
+Example:
+
+```json
+{
+  "httpHeaders": {
+    "Authorization": "Bearer YOUR_TOKEN_HERE"
+  }
+}
+```
+
+Make sure to replace `YOUR_TOKEN_HERE` with your actual token for authentication.
+
 ## How It Works
 
 ![Image](https://github.com/user-attachments/assets/48a587e4-7895-4a6f-9745-61b21894c34c)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -392,6 +392,27 @@ func processSingleMCPServer(
 	}
 }
 
+// resolveHTTPHeaders resolves environment variables in HTTP headers
+func resolveHTTPHeaders(headers map[string]string, logger *logging.Logger) map[string]string {
+	resolvedHeaders := make(map[string]string)
+	for k, v := range headers {
+		// Handle variable substitution from environment
+		if strings.HasPrefix(v, "${") && strings.HasSuffix(v, "}") {
+			envVar := strings.TrimSuffix(strings.TrimPrefix(v, "${"), "}")
+			if envValue := os.Getenv(envVar); envValue != "" {
+				resolvedHeaders[k] = envValue
+				logger.Debug("Substituted environment variable %s for HTTP header", envVar)
+			} else {
+				logger.Warn("Environment variable %s not found for HTTP header substitution", envVar)
+				resolvedHeaders[k] = "" // Set empty value
+			}
+		} else {
+			resolvedHeaders[k] = v
+		}
+	}
+	return resolvedHeaders
+}
+
 // createMCPClient creates an MCP client based on configuration
 // Use mcp.Client and mcp.NewClient from the internal mcp package
 func createMCPClient(logger *logging.Logger, serverConf config.MCPServerConfig, serverName string, _ *log.Logger) (*mcp.Client, error) {
@@ -404,8 +425,11 @@ func createMCPClient(logger *logging.Logger, serverConf config.MCPServerConfig, 
 		}
 		logger.InfoKV("Creating MCP client", "transport", transport, "address", serverConf.URL)
 
+		// Resolve HTTPHeaders environment variables for URL-based configurations
+		resolvedHeaders := resolveHTTPHeaders(serverConf.HTTPHeaders, logger)
+
 		// Use the imported mcp.NewClient from internal/mcp/client.go with structured logger
-		mcpClient, createErr := mcp.NewClient(transport, serverConf.URL, serverName, nil, nil, logger)
+		mcpClient, createErr := mcp.NewClient(transport, serverConf.URL, serverName, nil, nil, resolvedHeaders, logger)
 		if createErr != nil {
 			logger.Error("Failed to create MCP client for URL %s: %v", serverConf.URL, createErr)
 			// Create a domain-specific error with additional context
@@ -443,9 +467,12 @@ func createMCPClient(logger *logging.Logger, serverConf config.MCPServerConfig, 
 			}
 		}
 
-		// Create the MCP client
-		logger.DebugKV("Executing command", "command", serverConf.Command, "args", serverConf.Args, "env", env)
-		mcpClient, createErr := mcp.NewClient(transport, serverConf.Command, serverName, serverConf.Args, env, logger)
+		// Resolve HTTPHeaders environment variables
+		resolvedHeaders := resolveHTTPHeaders(serverConf.HTTPHeaders, logger)
+
+// Create the MCP client
+logger.DebugKV("Executing command", "command", serverConf.Command, "args", serverConf.Args, "env", env, "headers", resolvedHeaders)
+		mcpClient, createErr := mcp.NewClient(transport, serverConf.Command, serverName, serverConf.Args, env, resolvedHeaders, logger)
 		if createErr != nil {
 			logger.Error("Failed to create MCP client: %v", createErr)
 			// Create a domain-specific error with additional context

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/prometheus/client_golang v1.22.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/slack-go/slack v0.16.0
+	github.com/stretchr/testify v1.10.0
 	github.com/tmc/langchaingo v0.1.13
 )
 
@@ -23,6 +24,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.10.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
@@ -45,6 +47,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.9 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkoukk/tiktoken-go v0.1.7 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,6 +62,7 @@ type MCPServerConfig struct {
 	URL                      string            `json:"url,omitempty"`
 	Transport                string            `json:"transport,omitempty"`
 	Env                      map[string]string `json:"env,omitempty"`
+	HTTPHeaders              map[string]string `json:"httpHeaders,omitempty"`
 	Disabled                 bool              `json:"disabled,omitempty"`
 	InitializeTimeoutSeconds *int              `json:"initializeTimeoutSeconds,omitempty"`
 	Tools                    MCPToolsConfig    `json:"tools,omitempty"`

--- a/internal/mcp/sseClient.go
+++ b/internal/mcp/sseClient.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/mark3labs/mcp-go/client/transport"
+	"net/http"
 	"sync"
 	"time"
 
 	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
 )
@@ -22,6 +23,7 @@ type SSEMCPClientWithRetry struct {
 	*client.Client
 
 	serverAddr string
+	headers    http.Header
 	log        *logging.Logger
 
 	ctx    context.Context
@@ -35,8 +37,16 @@ type SSEMCPClientWithRetry struct {
 	reconnectDoneCh       chan struct{}
 }
 
-func NewSSEMCPClientWithRetry(serverAddr string, log *logging.Logger) (*SSEMCPClientWithRetry, error) {
-	sseClient, err := client.NewSSEMCPClient(serverAddr)
+func NewSSEMCPClientWithRetry(serverAddr string, hdr http.Header, log *logging.Logger) (*SSEMCPClientWithRetry, error) {
+	// Convert http.Header to map[string]string for the client library
+	headerMap := make(map[string]string)
+	for key, values := range hdr {
+		if len(values) > 0 {
+			headerMap[key] = values[0] // Use the first value for each header
+		}
+	}
+	
+	sseClient, err := client.NewSSEMCPClient(serverAddr, client.WithHeaders(headerMap))
 	if err != nil {
 		return nil, err
 	}
@@ -46,6 +56,7 @@ func NewSSEMCPClientWithRetry(serverAddr string, log *logging.Logger) (*SSEMCPCl
 	c := &SSEMCPClientWithRetry{
 		Client:     sseClient,
 		serverAddr: serverAddr,
+		headers:    hdr,
 		log:        log,
 		ctx:        ctx,
 		cancel:     cancel,
@@ -116,7 +127,15 @@ func (c *SSEMCPClientWithRetry) connect() error {
 		}
 	}
 
-	sseClient, err := client.NewSSEMCPClient(c.serverAddr)
+	// Convert http.Header to map[string]string for the client library
+	headerMap := make(map[string]string)
+	for key, values := range c.headers {
+		if len(values) > 0 {
+			headerMap[key] = values[0] // Use the first value for each header
+		}
+	}
+
+	sseClient, err := client.NewSSEMCPClient(c.serverAddr, client.WithHeaders(headerMap))
 	if err != nil {
 		return err
 	}

--- a/internal/mcp/sseClient_test.go
+++ b/internal/mcp/sseClient_test.go
@@ -1,0 +1,20 @@
+package mcp
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSSEMCPClientWithRetry_HeadersPropagation(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer some-token")
+	headers.Set("Custom-Header", "custom-value")
+
+	client, err := NewSSEMCPClientWithRetry("http://example.com", headers, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.Equal(t, "Bearer some-token", client.headers.Get("Authorization"))
+	assert.Equal(t, "custom-value", client.headers.Get("Custom-Header"))
+}

--- a/slack-mcp-client.json
+++ b/slack-mcp-client.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "./schema/config-schema.json",
+  "version": "2.0",
+  "slack": {
+    "botToken": "${SLACK_BOT_TOKEN}",
+    "appToken": "${SLACK_APP_TOKEN}"
+  },
+  "llm": {
+    "provider": "openai",
+    "providers": {
+      "openai": {
+        "apiKey": "${OPENAI_API_KEY}"
+      }
+    }
+  },
+  "mcpServers": {
+    "home-assistant": {
+      "transport": "sse",
+      "url": "${SSE_URL}",
+      "httpHeaders": {
+        "Authorization": "Bearer ${API_ACCESS_TOKEN}"
+      }
+    },
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/workspace"]
+    }
+  }
+}


### PR DESCRIPTION
- Add httpHeaders field to MCPServerConfig for custom HTTP headers
- Support environment variable substitution in header values (${VAR})
- Extend SSE MCP client to accept and use custom HTTP headers
- Update client creation flow to pass headers to SSE transport
- Add documentation for authenticating to SSE MCP servers
- Update CHANGELOG.md with new feature

This enables authentication with SSE MCP servers using Bearer tokens or other HTTP header-based authentication mechanisms.

Related to: https://github.com/tuannvm/slack-mcp-client/issues/97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for custom HTTP headers (e.g., Authorization bearer tokens) when connecting to SSE MCP servers, with environment-variable substitution for header values.

* **Documentation**
  * README updated with instructions for authenticating to SSE MCP servers using HTTP headers.
  * Changelog updated to reflect the new HTTP headers feature.

* **Tests**
  * Added tests to verify HTTP header propagation for SSE MCP client connections.

* **Chores**
  * Added testing-related dependencies and a sample configuration demonstrating Slack, LLM, and MCP server setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->