### PR TITLE
fix: skip Slack context parameters in tool call execution

### DIFF
--- a/internal/handlers/llm_mcp_bridge.go
+++ b/internal/handlers/llm_mcp_bridge.go
@@ -442,6 +442,12 @@ func (b *LLMMCPBridge) getClientForTool(toolName string) mcp.MCPClientInterface 
 // executeToolCall executes a detected tool call (using the new ToolCall struct)
 func (b *LLMMCPBridge) executeToolCall(ctx context.Context, toolCall *ToolCall, extraArgs map[string]interface{}) (string, error) {
 	for k, v := range extraArgs {
+		// Skip Slack context parameters as they're for internal tracking, not tool parameters
+		if k == "channel_id" || k == "thread_ts" {
+			b.logger.DebugKV("Skipping Slack context parameter", "key", k, "tool", toolCall.Tool)
+			continue
+		}
+
 		// Add any extra arguments to the tool call args
 		if toolCall.Args == nil {
 			toolCall.Args = make(map[string]interface{})


### PR DESCRIPTION
I noticed some MCP servers don't quite like having the `channel_id` and `thread_ts` from Slack context when executing tool calls, namely the Notion MCP was having problems with that and thus I removed that from the tool call.
