### PR TITLE
Comply with Go semantic import versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ flowchart LR
    - OpenAI Vector Store for semantic search and enterprise-grade RAG
 4. **Tool Ecosystem** connects to diverse external systems:
    - Filesystem operations for file management
-   - Git integration for repository interactions  
+   - Git integration for repository interactions
    - Kubernetes cluster management and monitoring
    - Custom tools via HTTP, SSE, or stdio protocols
 5. **Infrastructure** ensures production-ready deployment:
@@ -141,11 +141,11 @@ flowchart LR
 
 ## Features
 
-- ✅ **Multi-Mode MCP Client**: 
+- ✅ **Multi-Mode MCP Client**:
   - Server-Sent Events (SSE) for real-time communication with automatic retry
   - HTTP transport for JSON-RPC
   - stdio for local development and testing
-- ✅ **Slack Integration**: 
+- ✅ **Slack Integration**:
   - Uses Socket Mode for secure, firewall-friendly communication
   - Works with both channels and direct messages
   - Rich message formatting with Markdown and Block Kit
@@ -154,7 +154,7 @@ flowchart LR
   - Customizable bot behavior and message history
 - ✅ **Multi-Provider LLM Support**:
   - OpenAI (GPT-4, GPT-4o, etc.)
-  - Anthropic (Claude 3.5 Sonnet, etc.) 
+  - Anthropic (Claude 3.5 Sonnet, etc.)
   - Ollama (Local LLMs like Llama, Mistral, etc.)
   - Native tool calling and agent mode support
   - LangChain gateway for unified API
@@ -164,7 +164,7 @@ flowchart LR
   - Configurable agent iterations and behavior
   - Streaming responses with real-time updates
   - Advanced prompt engineering capabilities
-- ✅ **RAG (Retrieval-Augmented Generation)**: 
+- ✅ **RAG (Retrieval-Augmented Generation)**:
   - Multiple providers: Simple JSON storage, OpenAI Vector Store
   - Reusable vector stores with `vectorStoreId` support
   - Configurable search parameters and similarity metrics
@@ -199,7 +199,7 @@ Download the latest binary from the [GitHub releases page](https://github.com/tu
 
 ```bash
 # Install latest version using Go
-go install github.com/tuannvm/slack-mcp-client@latest
+go install github.com/tuannvm/slack-mcp-client/v2@latest
 
 # Or build from source
 git clone https://github.com/tuannvm/slack-mcp-client.git
@@ -508,7 +508,11 @@ Enable Agent Mode in your configuration file:
   "mcpServers": {
     "filesystem": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path/to/project"]
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/path/to/project"
+      ]
     },
     "github": {
       "command": "github-mcp-server",

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,15 +17,15 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/tuannvm/slack-mcp-client/internal/app"
-	customErrors "github.com/tuannvm/slack-mcp-client/internal/common/errors"
-	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
-	"github.com/tuannvm/slack-mcp-client/internal/config"
-	"github.com/tuannvm/slack-mcp-client/internal/mcp"
-	"github.com/tuannvm/slack-mcp-client/internal/monitoring"
-	"github.com/tuannvm/slack-mcp-client/internal/rag"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/app"
+	customErrors "github.com/tuannvm/slack-mcp-client/v2/internal/common/errors"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/common/logging"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/config"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/mcp"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/monitoring"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/rag"
 
-	slackbot "github.com/tuannvm/slack-mcp-client/internal/slack"
+	slackbot "github.com/tuannvm/slack-mcp-client/v2/internal/slack"
 )
 
 // ToolInfo definition is moved to internal/common/types.go

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tuannvm/slack-mcp-client
+module github.com/tuannvm/slack-mcp-client/v2
 
 go 1.24.2
 

--- a/internal/app/lifecycle.go
+++ b/internal/app/lifecycle.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
-	"github.com/tuannvm/slack-mcp-client/internal/config"
-	"github.com/tuannvm/slack-mcp-client/internal/monitoring"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/common/logging"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/config"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/monitoring"
 )
 
 const (

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/joho/godotenv"
 	"github.com/santhosh-tekuri/jsonschema/v5"
-	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/common/logging"
 )
 
 // ValidateAfterDefaults validates configuration after defaults and env substitution

--- a/internal/handlers/handler.go
+++ b/internal/handlers/handler.go
@@ -5,7 +5,7 @@ import (
 	"context"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/common/logging"
 )
 
 // ToolHandler defines the interface for all MCP tool handlers

--- a/internal/handlers/llm_mcp_bridge.go
+++ b/internal/handlers/llm_mcp_bridge.go
@@ -16,12 +16,12 @@ import (
 	"github.com/tmc/langchaingo/callbacks"
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/tools"
-	"github.com/tuannvm/slack-mcp-client/internal/llm"
-	"github.com/tuannvm/slack-mcp-client/internal/mcp"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/llm"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/mcp"
 
-	customErrors "github.com/tuannvm/slack-mcp-client/internal/common/errors"
-	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
-	"github.com/tuannvm/slack-mcp-client/internal/config"
+	customErrors "github.com/tuannvm/slack-mcp-client/v2/internal/common/errors"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/common/logging"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/config"
 )
 
 // LLMMCPBridge provides a bridge between LLM responses and MCP tool calls.

--- a/internal/handlers/registry.go
+++ b/internal/handlers/registry.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/common/logging"
 )
 
 // Registry manages all available tool handlers

--- a/internal/llm/anthropic_factory.go
+++ b/internal/llm/anthropic_factory.go
@@ -3,8 +3,8 @@ package llm
 import (
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/llms/anthropic"
-	customErrors "github.com/tuannvm/slack-mcp-client/internal/common/errors"
-	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
+	customErrors "github.com/tuannvm/slack-mcp-client/v2/internal/common/errors"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/common/logging"
 )
 
 // AnthropicModelFactory creates Anthropic LangChain model instances

--- a/internal/llm/langchain.go
+++ b/internal/llm/langchain.go
@@ -12,8 +12,8 @@ import (
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/tools"
 
-	"github.com/tuannvm/slack-mcp-client/internal/common/errors"
-	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/common/errors"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/common/logging"
 )
 
 const (

--- a/internal/llm/ollama_factory.go
+++ b/internal/llm/ollama_factory.go
@@ -3,8 +3,8 @@ package llm
 import (
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/llms/ollama"
-	customErrors "github.com/tuannvm/slack-mcp-client/internal/common/errors"
-	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
+	customErrors "github.com/tuannvm/slack-mcp-client/v2/internal/common/errors"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/common/logging"
 )
 
 // OllamaModelFactory creates Ollama LangChain model instances

--- a/internal/llm/openai_factory.go
+++ b/internal/llm/openai_factory.go
@@ -6,9 +6,9 @@ import (
 	"github.com/tmc/langchaingo/callbacks"
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/llms/openai"
-	customErrors "github.com/tuannvm/slack-mcp-client/internal/common/errors"
-	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
-	"github.com/tuannvm/slack-mcp-client/internal/monitoring"
+	customErrors "github.com/tuannvm/slack-mcp-client/v2/internal/common/errors"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/common/logging"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/monitoring"
 )
 
 type handleContentEndFunc func(res *llms.ContentResponse)

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -10,7 +10,7 @@ import (
 	"github.com/tmc/langchaingo/callbacks"
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/tools"
-	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/common/logging"
 )
 
 // Constants for provider types and names

--- a/internal/llm/registry.go
+++ b/internal/llm/registry.go
@@ -9,8 +9,8 @@ import (
 	"github.com/tmc/langchaingo/callbacks"
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/tools"
-	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
-	"github.com/tuannvm/slack-mcp-client/internal/config" // Import config
+	"github.com/tuannvm/slack-mcp-client/v2/internal/common/logging"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/config" // Import config
 )
 
 // ProviderRegistry manages all available LLM providers

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -15,8 +15,8 @@ import (
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/mcp"
 
-	customErrors "github.com/tuannvm/slack-mcp-client/internal/common/errors"
-	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
+	customErrors "github.com/tuannvm/slack-mcp-client/v2/internal/common/errors"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/common/logging"
 )
 
 // MCPClientInterface defines the interface for an MCP client

--- a/internal/mcp/mcpTool.go
+++ b/internal/mcp/mcpTool.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/tuannvm/slack-mcp-client/internal/monitoring"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/monitoring"
 )
 
 type ToolInfo struct {

--- a/internal/mcp/sseClient.go
+++ b/internal/mcp/sseClient.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/common/logging"
 )
 
 const (

--- a/internal/observability/interface.go
+++ b/internal/observability/interface.go
@@ -2,8 +2,8 @@ package observability
 
 import (
 	"context"
-	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
-	"github.com/tuannvm/slack-mcp-client/internal/config"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/common/logging"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/config"
 	"go.opentelemetry.io/otel/trace"
 	"time"
 )

--- a/internal/observability/langfuse.go
+++ b/internal/observability/langfuse.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
-	"github.com/tuannvm/slack-mcp-client/internal/config"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/common/logging"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/config"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"

--- a/internal/observability/simple.go
+++ b/internal/observability/simple.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
-	"github.com/tuannvm/slack-mcp-client/internal/config"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/common/logging"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/config"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"

--- a/internal/slack/client.go
+++ b/internal/slack/client.go
@@ -15,14 +15,14 @@ import (
 
 	"github.com/tmc/langchaingo/callbacks"
 	"github.com/tmc/langchaingo/llms"
-	customErrors "github.com/tuannvm/slack-mcp-client/internal/common/errors"
-	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
-	"github.com/tuannvm/slack-mcp-client/internal/config"
-	"github.com/tuannvm/slack-mcp-client/internal/handlers"
-	"github.com/tuannvm/slack-mcp-client/internal/llm"
-	"github.com/tuannvm/slack-mcp-client/internal/mcp"
-	"github.com/tuannvm/slack-mcp-client/internal/observability"
-	"github.com/tuannvm/slack-mcp-client/internal/rag"
+	customErrors "github.com/tuannvm/slack-mcp-client/v2/internal/common/errors"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/common/logging"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/config"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/handlers"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/llm"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/mcp"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/observability"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/rag"
 )
 
 // Client represents the Slack client application.

--- a/internal/slack/stdioClient.go
+++ b/internal/slack/stdioClient.go
@@ -6,7 +6,7 @@ import (
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
 	"github.com/slack-go/slack/socketmode"
-	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/common/logging"
 	"io"
 	"os"
 	"os/user"

--- a/internal/slack/userFrontend.go
+++ b/internal/slack/userFrontend.go
@@ -10,9 +10,9 @@ import (
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/socketmode"
 
-	customErrors "github.com/tuannvm/slack-mcp-client/internal/common/errors"
-	"github.com/tuannvm/slack-mcp-client/internal/common/logging"
-	"github.com/tuannvm/slack-mcp-client/internal/slack/formatter"
+	customErrors "github.com/tuannvm/slack-mcp-client/v2/internal/common/errors"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/common/logging"
+	"github.com/tuannvm/slack-mcp-client/v2/internal/slack/formatter"
 )
 
 type UserFrontend interface {


### PR DESCRIPTION
# Problem trying to solve

Cannot install `slack-mcp-client` versions with major v2, since do not comply with Go semantic versioning.

## What I execute

Install any 2+ version using go. Example:

```bash
go install github.com/tuannvm/slack-mcp-client@v2.6.0
```

## Error returned

```
go: github.com/tuannvm/slack-mcp-client@v2.6.0: github.com/tuannvm/slack-mcp-client@v2.6.0: invalid version: module contains a go.mod file, so module path must match major version ("github.com/tuannvm/slack-mcp-client/v2")
```

Also installing latest version doesn't work either:

```
go: github.com/tuannvm/slack-mcp-client@latest: module github.com/tuannvm/slack-mcp-client@latest found (v1.9.1), but does not contain package github.com/tuannvm/slack-mcp-client
```

## Proposed solution

Include the major version in the module path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Expanded RAG docs: PDF ingestion with intelligent chunking and CLI tools for document management.
  - Updated installation command to use the v2 module path.
  - Clarified Agent Mode configuration example (multiline args formatting).
  - Minor formatting and readability improvements across sections.

- Chores
  - Upgraded project to v2 module path and aligned internal references; no user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->