### PR TITLE
Add stdio client back into config as an option

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -630,14 +630,19 @@ func startSlackClient(logger *logging.Logger, mcpClients map[string]*mcp.Client,
 	var err error
 
 	var userFrontend slackbot.UserFrontend
-	userFrontend, err = slackbot.GetSlackClient(
-		cfg.Slack.BotToken,
-		cfg.Slack.AppToken,
-		logger,
-		cfg.Slack.ThinkingMessage,
-	)
-	if err != nil {
-		logger.Fatal("Failed to initialize Slack client: %v", err)
+	// Use the structured logger for the Slack client
+	if cfg.UseStdIOClient {
+		userFrontend = slackbot.NewStdioClient(logger)
+	} else {
+		userFrontend, err = slackbot.GetSlackClient(
+			cfg.Slack.BotToken,
+			cfg.Slack.AppToken,
+			logger,
+			cfg.Slack.ThinkingMessage,
+		)
+		if err != nil {
+			logger.Fatal("Failed to initialize Slack client: %v", err)
+		}
 	}
 
 	// Use the structured logger for the Slack client

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,16 +22,17 @@ const (
 
 // Config represents the main application configuration
 type Config struct {
-	Version       string                     `json:"version"`
-	Slack         SlackConfig                `json:"slack"`
-	LLM           LLMConfig                  `json:"llm"`
-	MCPServers    map[string]MCPServerConfig `json:"mcpServers"`
-	RAG           RAGConfig                  `json:"rag,omitempty"`
-	Monitoring    MonitoringConfig           `json:"monitoring,omitempty"`
-	Timeouts      TimeoutConfig              `json:"timeouts,omitempty"`
-	Retry         RetryConfig                `json:"retry,omitempty"`
-	Reload        ReloadConfig               `json:"reload,omitempty"`
-	Observability ObservabilityConfig        `json:"observability,omitempty"`
+	Version        string                     `json:"version"`
+	Slack          SlackConfig                `json:"slack"`
+	LLM            LLMConfig                  `json:"llm"`
+	MCPServers     map[string]MCPServerConfig `json:"mcpServers"`
+	RAG            RAGConfig                  `json:"rag,omitempty"`
+	Monitoring     MonitoringConfig           `json:"monitoring,omitempty"`
+	Timeouts       TimeoutConfig              `json:"timeouts,omitempty"`
+	Retry          RetryConfig                `json:"retry,omitempty"`
+	Reload         ReloadConfig               `json:"reload,omitempty"`
+	Observability  ObservabilityConfig        `json:"observability,omitempty"`
+	UseStdIOClient bool                       `json:"useStdIOClient,omitempty"` // Use terminal client instead of a real slack bot, for local development
 }
 
 // SlackConfig contains Slack-specific configuration

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -16,12 +16,14 @@ import (
 
 // ValidateAfterDefaults validates configuration after defaults and env substitution
 func (c *Config) ValidateAfterDefaults() error {
-	// Validate required fields after environment substitution
-	if c.Slack.BotToken == "" || strings.HasPrefix(c.Slack.BotToken, "${") {
-		return fmt.Errorf("SLACK_BOT_TOKEN environment variable not set")
-	}
-	if c.Slack.AppToken == "" || strings.HasPrefix(c.Slack.AppToken, "${") {
-		return fmt.Errorf("SLACK_APP_TOKEN environment variable not set")
+	if !c.UseStdIOClient {
+		// Validate required fields after environment substitution
+		if c.Slack.BotToken == "" || strings.HasPrefix(c.Slack.BotToken, "${") {
+			return fmt.Errorf("SLACK_BOT_TOKEN environment variable not set")
+		}
+		if c.Slack.AppToken == "" || strings.HasPrefix(c.Slack.AppToken, "${") {
+			return fmt.Errorf("SLACK_APP_TOKEN environment variable not set")
+		}
 	}
 
 	// Validate LLM provider exists


### PR DESCRIPTION
Hello again! Been a while since I've been doing local dev on this. I see the stdio client option was removed as part of the config refactor (https://github.com/tuannvm/slack-mcp-client/pull/76). This adds it back, as it is very useful to work on things without necessarily needing to go through slack