### PR TITLE
Fixed thinking message deletion

### DIFF
--- a/internal/slack/userFrontend.go
+++ b/internal/slack/userFrontend.go
@@ -167,12 +167,9 @@ func (slackClient *SlackClient) SendMessage(channelID, threadTS, text string) {
 
 	// Delete "typing" indicator messages if any
 	// This is a simplistic approach - more sophisticated approaches might track message IDs
-	history, err := slackClient.GetConversationHistory(&slack.GetConversationHistoryParameters{
-		ChannelID: channelID,
-		Limit:     10,
-	})
+	history, err := slackClient.GetThreadReplies(channelID, threadTS)
 	if err == nil && history != nil {
-		for _, msg := range history.Messages {
+		for _, msg := range history {
 			if slackClient.IsBotUser(msg.User) && msg.Text == slackClient.thinkingMessage {
 				_, _, err := slackClient.DeleteMessage(channelID, msg.Timestamp)
 				if err != nil {


### PR DESCRIPTION
* Changed existing logic to use GetThreadReplies for deleting Thinking message after actual AI response.
* Fixes the issue https://github.com/tuannvm/slack-mcp-client/issues/140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Slack thread message handling by fetching thread replies directly instead of retrieving general channel history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->