### PR TITLE
Make the tool execution error available in the chat, so the agent can act on it.

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -215,7 +215,7 @@ func (c *Client) CallTool(ctx context.Context, toolName string, args map[string]
 
 		c.logger.ErrorKV("Tool execution error", "tool", toolName, "error", errMsgText)
 		return "", customErrors.NewMCPError("tool_execution_error",
-			fmt.Sprintf("Tool '%s' returned an error", toolName)).WithData("error_message", errMsgText)
+			fmt.Sprintf("Tool '%s' returned an error: %s", toolName, errMsgText)).WithData("error_message", errMsgText)
 	}
 
 	// Extract text content from the result


### PR DESCRIPTION
This pull request makes a minor improvement to error reporting in the `CallTool` method of the `Client` struct. The returned error message now includes the specific error text from the tool, enabling the agent to act on it's tool execution failures.

* Improved the error message in `CallTool` to include the actual error returned by the tool, providing more context for debugging (`internal/mcp/client.go`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages when tools fail by including the actual error details, providing more context for troubleshooting instead of generic error notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->